### PR TITLE
mvvm-live-kotlin: added task filter label update to view model start()

### DIFF
--- a/todoapp/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.kt
+++ b/todoapp/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.kt
@@ -150,6 +150,9 @@ import org.junit.runner.RunWith
 
         // Verify task is displayed on screen
         onView(withItemText(TITLE1)).check(matches(isDisplayed()))
+
+        // Verify filter label is not empty string
+        onView(withId(R.id.filteringLabel)).check(matches(not(withText(""))))
     }
 
     @Test fun markTaskAsComplete() {
@@ -198,6 +201,8 @@ import org.junit.runner.RunWith
         viewAllTasks()
         onView(withItemText(TITLE1)).check(matches(isDisplayed()))
         onView(withItemText(TITLE2)).check(matches(isDisplayed()))
+
+        onView(withId(R.id.filteringLabel)).check(matches(not(withText(""))))
     }
 
     @Test fun showActiveTasks() {
@@ -209,6 +214,8 @@ import org.junit.runner.RunWith
         viewActiveTasks()
         onView(withItemText(TITLE1)).check(matches(isDisplayed()))
         onView(withItemText(TITLE2)).check(matches(isDisplayed()))
+
+        onView(withId(R.id.filteringLabel)).check(matches(not(withText(""))))
     }
 
     @Test fun showCompletedTasks() {
@@ -222,6 +229,8 @@ import org.junit.runner.RunWith
         viewCompletedTasks()
         onView(withItemText(TITLE1)).check(matches(isDisplayed()))
         onView(withItemText(TITLE2)).check(matches(isDisplayed()))
+
+        onView(withId(R.id.filteringLabel)).check(matches(not(withText(""))))
     }
 
     @Test fun clearCompletedTasks() {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
@@ -76,6 +76,7 @@ class TasksViewModel(
 
     fun start() {
         loadTasks(false)
+        updateFiltering()
     }
 
     fun loadTasks(forceUpdate: Boolean) {


### PR DESCRIPTION
To match some of the other TO-DO samples, I added the setting of the task filter label to when you start with tasks and when adding a first new task.  I updated a few test cases for this as well.