### PR TITLE
Use a consistent process for attaching Fragment to Activity

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskActivity.kt
@@ -48,7 +48,7 @@ class AddEditTaskActivity : AppCompatActivity(), AddEditTaskNavigator {
             setDisplayShowHomeEnabled(true)
         }
 
-        replaceFragmentInActivity(obtainViewFragment(), R.id.contentFrame)
+        setupViewFragment()
 
         subscribeToNavigationChanges()
     }
@@ -60,13 +60,17 @@ class AddEditTaskActivity : AppCompatActivity(), AddEditTaskNavigator {
         })
     }
 
-    private fun obtainViewFragment() = supportFragmentManager.findFragmentById(R.id.contentFrame) ?:
+    private fun setupViewFragment() {
+        supportFragmentManager.findFragmentById(R.id.contentFrame) ?: replaceFragmentInActivity(
             AddEditTaskFragment.newInstance().apply {
                 arguments = Bundle().apply {
                     putString(AddEditTaskFragment.ARGUMENT_EDIT_TASK_ID,
                             intent.getStringExtra(AddEditTaskFragment.ARGUMENT_EDIT_TASK_ID))
                 }
-            }
+            },
+            R.id.contentFrame
+        )
+    }
 
     fun obtainViewModel(): AddEditTaskViewModel = obtainViewModel(AddEditTaskViewModel::class.java)
 

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsActivity.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsActivity.kt
@@ -57,14 +57,15 @@ class StatisticsActivity : AppCompatActivity() {
 
         setupNavigationDrawer()
 
-        findOrCreateViewFragment()
+        setupViewFragment()
     }
 
-    private fun findOrCreateViewFragment() =
-            supportFragmentManager.findFragmentById(R.id.contentFrame) ?:
-                    StatisticsFragment.newInstance().also {
-                        replaceFragmentInActivity(it, R.id.contentFrame)
-                    }
+    private fun setupViewFragment() {
+        supportFragmentManager.findFragmentById(R.id.contentFrame) ?: replaceFragmentInActivity(
+            StatisticsFragment.newInstance(),
+            R.id.contentFrame
+        )
+    }
 
     private fun setupNavigationDrawer() {
         drawerLayout = (findViewById<DrawerLayout>(R.id.drawer_layout)).apply {

--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailActivity.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailActivity.kt
@@ -47,16 +47,19 @@ class TaskDetailActivity : AppCompatActivity(), TaskDetailNavigator {
             setDisplayShowHomeEnabled(true)
         }
 
-        replaceFragmentInActivity(findOrCreateViewFragment(), R.id.contentFrame)
+        setupViewFragment()
 
         taskViewModel = obtainViewModel()
 
         subscribeToNavigationChanges(taskViewModel)
     }
 
-    private fun findOrCreateViewFragment() =
-            supportFragmentManager.findFragmentById(R.id.contentFrame) ?:
-                    TaskDetailFragment.newInstance(intent.getStringExtra(EXTRA_TASK_ID))
+    private fun setupViewFragment() {
+        supportFragmentManager.findFragmentById(R.id.contentFrame) ?: replaceFragmentInActivity(
+            TaskDetailFragment.newInstance(intent.getStringExtra(EXTRA_TASK_ID)),
+            R.id.contentFrame
+        )
+    }
 
     private fun subscribeToNavigationChanges(viewModel: TaskDetailViewModel) {
         // The activity observes the navigation commands in the ViewModel


### PR DESCRIPTION
This addresses two issues

1. Use a consistent process across the app's four Activities for attaching the primary Fragment. I've used the existing naming and style from TasksActivity elsewhere. The Fragment is now always configured in a function called `setupViewFragment()`.
2. Only invoke `replaceFragmentInActivity()` if the Fragment is not already present in the FragmentManager. This prevents re-attaching the same Fragment that the system has already recreated upon configuration changes.