### PR TITLE
Omit verbose return type & simplify return syntax

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/Result.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/Result.kt
@@ -28,12 +28,10 @@ sealed class Result<out R> {
     data class Error(val exception: Exception) : Result<Nothing>()
     object Loading : Result<Nothing>()
 
-    override fun toString(): String {
-        return when (this) {
-            is Success<*> -> "Success[data=$data]"
-            is Error -> "Error[exception=$exception]"
-            Loading -> "Loading"
-        }
+    override fun toString() = when (this) {
+        is Success<*> -> "Success[data=$data]"
+        is Error -> "Error[exception=$exception]"
+        Loading -> "Loading"
     }
 }
 


### PR DESCRIPTION
Return type is already clear by the method name.