### PR TITLE
Prevent direct instantiation.

### DIFF
--- a/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
+++ b/todoapp/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
@@ -27,7 +27,7 @@ import java.util.LinkedHashMap
  * obtained from the server, by using the remote data source only if the local database doesn't
  * exist or is empty.
  */
-class TasksRepository(
+class TasksRepository private constructor(
         val tasksRemoteDataSource: TasksDataSource,
         val tasksLocalDataSource: TasksDataSource
 ) : TasksDataSource {


### PR DESCRIPTION
Using private constructor instead of public constructor is better for singleton pattern.