### PR TITLE
Remove unused singleton imports

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/di/ViewModelFactory.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/di/ViewModelFactory.kt
@@ -22,7 +22,6 @@ import dagger.MapKey
 import dagger.Module
 import javax.inject.Inject
 import javax.inject.Provider
-import javax.inject.Singleton
 import kotlin.reflect.KClass
 
 /**


### PR DESCRIPTION
Remove the import:
```kotlin
import javax.inject.Singleton
```
I believe the annotation was there for the ```ViewModelFactory.kt ``` and then removed due to similar issue in this link: https://github.com/google/dagger/issues/1607