### PR TITLE
Remove .applicationContext

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/di/AppModule.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/di/AppModule.kt
@@ -76,7 +76,7 @@ object AppModule {
     @Provides
     fun provideDataBase(@ApplicationContext context: Context): ToDoDatabase {
         return Room.databaseBuilder(
-            context.applicationContext,
+            context,
             ToDoDatabase::class.java,
             "Tasks.db"
         ).build()


### PR DESCRIPTION
I think you can use `context` instead of `context.applicationContext`.