### PR TITLE
NavHostController extension for HiltExt.kt

### DIFF
--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/HiltExt.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/HiltExt.kt
@@ -23,6 +23,8 @@ import androidx.annotation.StyleRes
 import androidx.core.util.Preconditions
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.testing.FragmentScenario.EmptyFragmentActivity
+import androidx.navigation.Navigation
+import androidx.navigation.NavHostController
 import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 

--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/HiltExt.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/HiltExt.kt
@@ -38,6 +38,7 @@ import androidx.test.core.app.ApplicationProvider
 inline fun <reified T : Fragment> launchFragmentInHiltContainer(
     fragmentArgs: Bundle? = null,
     @StyleRes themeResId: Int = R.style.FragmentScenarioEmptyFragmentActivityTheme,
+    navHostController: NavHostController? = null,
     crossinline action: Fragment.() -> Unit = {}
 ) {
     val startActivityIntent = Intent.makeMainActivity(
@@ -53,6 +54,13 @@ inline fun <reified T : Fragment> launchFragmentInHiltContainer(
             T::class.java.name
         )
         fragment.arguments = fragmentArgs
+        fragment.viewLifecycleOwnerLiveData.observeForever { viewLifecycleOwner ->
+            if (viewLifecycleOwner != null) {
+                navHostController?.let {
+                    Navigation.setViewNavController(fragment.requireView(), it)
+                }
+            }
+        }
         activity.supportFragmentManager
             .beginTransaction()
             .add(android.R.id.content, fragment, "")


### PR DESCRIPTION
We are able provide `NavHostController` to `FragmentScenario` for the Fragments which configures `Toolbar` by using `NavController`. 

We have `HiltExt.kt` workaround instead of `FragmentScenario` at the moment and it does not support this.
So, we need to provide `NavHostController` order to be able test the fragments which configure its Toolbar by using NavController.
Like:
```kotlin
   private fun configureToolbar() {
        val navController = findNavController()
        val appBarConfiguration = AppBarConfiguration(navController.graph)

        binding.toolbarLayout.toolbar
            .setupWithNavController(navController, appBarConfiguration)
    }
```

In test we need to do:

```kotlin
    private fun launchFragment() {
        val navController = TestNavHostController(
            ApplicationProvider.getApplicationContext()
        )
        navController.setGraph(R.navigation.navigation_recipe)
        val activityScenario =
            launchFragmentInHiltContainer<RecipeListFragment>(
                themeResId = R.style.AppTheme,
                navHostController = navController
            )
    }
```
