### PR TITLE
Deprecated in java fragment + FAB

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskFragment.kt
@@ -58,8 +58,8 @@ class AddEditTaskFragment : Fragment() {
         return viewDataBinding.root
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setupSnackbar()
         setupNavigation()
         this.setupRefreshLayout(viewDataBinding.refreshLayout)

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsFragment.kt
@@ -49,8 +49,8 @@ class StatisticsFragment : Fragment() {
         return viewDataBinding.root
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         viewDataBinding.viewmodel = viewModel
         viewDataBinding.lifecycleOwner = this.viewLifecycleOwner
         this.setupRefreshLayout(viewDataBinding.refreshLayout)

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailFragment.kt
@@ -46,10 +46,10 @@ class TaskDetailFragment : Fragment() {
 
     private val viewModel by viewModels<TaskDetailViewModel>()
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
         setupFab()
-        view?.setupSnackbar(this, viewModel.snackbarText, Snackbar.LENGTH_SHORT)
+        view.setupSnackbar(this, viewModel.snackbarText, Snackbar.LENGTH_SHORT)
         setupNavigation()
         this.setupRefreshLayout(viewDataBinding.refreshLayout)
     }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
@@ -134,11 +134,7 @@ class TasksFragment : Fragment() {
     }
 
     private fun setupFab() {
-        activity?.findViewById<FloatingActionButton>(R.id.add_task_fab)?.let {
-            it.setOnClickListener {
-                navigateToAddNewTask()
-            }
-        }
+        viewDataBinding.addTaskFab.setOnClickListener { navigateToAddNewTask() }
     }
 
     private fun navigateToAddNewTask() {

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksFragment.kt
@@ -86,8 +86,8 @@ class TasksFragment : Fragment() {
         inflater.inflate(R.menu.tasks_fragment_menu, menu)
     }
 
-    override fun onActivityCreated(savedInstanceState: Bundle?) {
-        super.onActivityCreated(savedInstanceState)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
 
         // Set the lifecycle owner to the lifecycle of the view
         viewDataBinding.lifecycleOwner = this.viewLifecycleOwner

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksListBindings.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksListBindings.kt
@@ -24,14 +24,14 @@ import com.example.android.architecture.blueprints.todoapp.data.Task
 /**
  * [BindingAdapter]s for the [Task]s list.
  */
-@BindingAdapter("app:items")
+@BindingAdapter("items")
 fun setItems(listView: RecyclerView, items: List<Task>?) {
     items?.let {
         (listView.adapter as TasksAdapter).submitList(items)
     }
 }
 
-@BindingAdapter("app:completedTask")
+@BindingAdapter("completedTask")
 fun setStyle(textView: TextView, enabled: Boolean) {
     if (enabled) {
         textView.paintFlags = textView.paintFlags or Paint.STRIKE_THRU_TEXT_FLAG


### PR DESCRIPTION
1. **Deprecated** onActivityView in Fragments replace on onViewCreated in all (4) Fragments
2. Application namespace for attribute app:completedTask will be ignored in **@BindingAdapter**
3. **FAB** - findViewById replace on viewDataBinding, because it does not work stably - sometimes FAB does not respond at the start app. As a result, unstable tests are obtained TasksActivityTest: > createOneTask_deleteTask() and createTask().
With the proposed changes, the tests become stable.
UI with the proposed changes also **responds stably**.