### PR TITLE
Create ScrollChildSwipeRefreshLayout

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ScrollChildSwipeRefreshLayout.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/ScrollChildSwipeRefreshLayout.kt
@@ -38,3 +38,6 @@ class ScrollChildSwipeRefreshLayout @JvmOverloads constructor(
     override fun canChildScrollUp() =
         scrollUpChild?.canScrollVertically(-1) ?: super.canChildScrollUp()
 }
+
+
+


### PR DESCRIPTION
//This is incase if the scrollup doesn't work

fun scrollChild(view: ScrollChildSwipeRefreshLayout? , availfirstItem : Int, availItemCount: Int, totalItemCount:Int){  

//If total item count is zero then it should reset back to initial state
var firstAvailItem = firstAvailItem

if (totalItemCount < scrollUpChild){
	this.currentPage = this.startingPageIndex
this.scrollUpChild = totalItemCount
if(totalItemCount = =0){
	this.loading = true
}

//If its loading check the count has changed or not and we can finish loading and update the current page no and total item count 
}
var loading
var currentPage
if (loading && totalItemCount > previousTotalItemCount){
loading = false
scrollUpChild = totalItemCount
currentPage++
}

var reverse
if(reverse){
	firstAvailItem = totalItemCount - firstAvailItem
}
var onLoad
if(!loading && totalItemCount - availItemCount <= firstAvialItem + canChildScrollUp){
	ScrollChildSwipeRefreshLayout(currentPage + 1, totalItemCount)
loading = true
}
}