### PR TITLE
Support test DialogFragment

### DIFF
--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/HiltExt.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/HiltExt.kt
@@ -55,11 +55,15 @@ inline fun <reified T : Fragment> launchFragmentInHiltContainer(
             T::class.java.name
         )
         fragment.arguments = fragmentArgs
-        activity.supportFragmentManager
-            .beginTransaction()
-            .add(android.R.id.content, fragment, "")
-            .commitNow()
-
+        
+        if (fragment is DialogFragment) {
+            fragment.show(activity.supportFragmentManager, "")
+        } else {
+            activity.supportFragmentManager
+                .beginTransaction()
+                .add(android.R.id.content, fragment, "")
+                .commitNow()
+        }
         fragment.action()
     }
 }


### PR DESCRIPTION
When the fragment is a `DialogFragment`, branch processing should be performed. Otherwise, the ui test may fall into a waiting state due to the `DialogFragment` animation.