### PR TITLE
Update test core to 1.4.1-alpha04

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ ext {
 
     // App dependencies
     androidXVersion = '1.0.0'
-    androidXTestCoreVersion = '1.4.0'
+    androidXTestCoreVersion = '1.4.1-alpha04'
     androidXTestExtKotlinRunnerVersion = '1.1.3'
     androidXTestRulesVersion = '1.2.0'
     androidXAnnotations = '1.3.0'


### PR DESCRIPTION
This allows instrumentation tests (`connected***Test`) to run again.

I did not investigate why Espresso `3.5.0-alpha04` and the previous version of test core resulted in no tests being run.