### PR TITLE
Experimental functional reactive state production

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskStateProducer.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskStateProducer.kt
@@ -1,0 +1,142 @@
+package com.example.android.architecture.blueprints.todoapp.addedittask
+
+import androidx.lifecycle.SavedStateHandle
+import com.example.android.architecture.blueprints.todoapp.R
+import com.example.android.architecture.blueprints.todoapp.TodoDestinationsArgs
+import com.example.android.architecture.blueprints.todoapp.data.Result
+import com.example.android.architecture.blueprints.todoapp.data.Task
+import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository
+import com.example.android.architecture.blueprints.todoapp.util.frp.StateChange
+import com.example.android.architecture.blueprints.todoapp.util.frp.stateProducer
+import com.example.android.architecture.blueprints.todoapp.util.frp.toStateChangeStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.merge
+
+sealed class Action {
+    data class Save(
+        val taskId: String?,
+        val title: String,
+        val description: String,
+        val taskCompleted: Boolean,
+    ) : Action()
+
+    data class UpdateTitle(val title: String) : Action()
+    data class UpdateDescription(val description: String) : Action()
+
+    object SnackBarMessageShown : Action()
+}
+
+fun addEditStateProducer(
+    scope: CoroutineScope,
+    tasksRepository: TasksRepository,
+    savedStateHandle: SavedStateHandle
+) = stateProducer<Action, AddEditTaskUiState>(
+    scope = scope,
+    initialState = AddEditTaskUiState(),
+    actionTransform = { actionStream ->
+        val taskId: String? = savedStateHandle[TodoDestinationsArgs.TASK_ID_ARG]
+        merge(
+            loadStateChanges(
+                taskId = taskId,
+                tasksRepository = tasksRepository
+            ),
+            actionStream.toStateChangeStream {
+                when (val type = type()) {
+                    is Action.Save -> type.flow.saveStateChanges(
+                        tasksRepository = tasksRepository
+                    )
+                    is Action.UpdateDescription -> type.flow.descriptionStateChanges()
+                    is Action.UpdateTitle -> type.flow.titleStateChanges()
+                    is Action.SnackBarMessageShown -> type.flow.snackbarMessageStateChanges()
+                }
+            }
+        )
+    }
+)
+
+private fun loadStateChanges(
+    taskId: String?,
+    tasksRepository: TasksRepository
+): Flow<StateChange<AddEditTaskUiState>> =
+    // Task does not exist yet, nothing to load
+    if (taskId == null) emptyFlow()
+    else flow {
+        emit(
+            StateChange {
+                copy(isLoading = true)
+            }
+        )
+
+        val result = tasksRepository.getTask(taskId)
+        emit(
+            when (result) {
+                is Result.Success -> StateChange {
+                    copy(
+                        title = result.data.title,
+                        description = result.data.description,
+                        isTaskCompleted = result.data.isCompleted,
+                        isLoading = false
+                    )
+                }
+                else -> StateChange {
+                    copy(isLoading = false)
+                }
+            }
+        )
+    }
+
+private fun Flow<Action.UpdateTitle>.titleStateChanges(): Flow<StateChange<AddEditTaskUiState>> =
+    mapLatest {
+        StateChange {
+            copy(title = it.title)
+        }
+    }
+
+private fun Flow<Action.UpdateDescription>.descriptionStateChanges(): Flow<StateChange<AddEditTaskUiState>> =
+    mapLatest {
+        StateChange {
+            copy(description = it.description)
+        }
+    }
+
+private fun Flow<Action.SnackBarMessageShown>.snackbarMessageStateChanges(): Flow<StateChange<AddEditTaskUiState>> =
+    mapLatest {
+        StateChange {
+            copy(userMessage = null)
+        }
+    }
+
+private fun Flow<Action.Save>.saveStateChanges(
+    tasksRepository: TasksRepository
+): Flow<StateChange<AddEditTaskUiState>> =
+    // Don't submit the same data twice
+    distinctUntilChanged()
+        .mapLatest { (taskId, title, description, taskCompleted) ->
+            if (title.isEmpty() || description.isEmpty()) StateChange<AddEditTaskUiState> {
+                copy(userMessage = R.string.empty_task_message)
+            }
+            else when (taskId) {
+                null -> tasksRepository.saveTask(
+                    Task(
+                        title = title,
+                        description = description
+                    )
+                )
+                else -> tasksRepository.saveTask(
+                    Task(
+                        title = title,
+                        description = description,
+                        isCompleted = taskCompleted,
+                        id = taskId
+                    )
+                )
+            }
+            StateChange {
+                copy(isTaskSaved = true)
+            }
+        }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsStateProducer.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsStateProducer.kt
@@ -1,0 +1,77 @@
+package com.example.android.architecture.blueprints.todoapp.statistics
+
+import com.example.android.architecture.blueprints.todoapp.data.Result
+import com.example.android.architecture.blueprints.todoapp.data.Task
+import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository
+import com.example.android.architecture.blueprints.todoapp.util.Async
+import com.example.android.architecture.blueprints.todoapp.util.frp.StateChange
+import com.example.android.architecture.blueprints.todoapp.util.frp.stateProducer
+import com.example.android.architecture.blueprints.todoapp.util.frp.toStateChangeStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onStart
+
+sealed class Action {
+    object Refresh : Action()
+}
+
+fun statisticsStateProducer(
+    scope: CoroutineScope,
+    tasksRepository: TasksRepository,
+) = stateProducer<Action, StatisticsUiState>(
+    scope = scope,
+    initialState = StatisticsUiState(isLoading = true),
+    actionTransform = { actionStream ->
+        merge(
+            loadStateChanges(tasksRepository),
+            actionStream.toStateChangeStream {
+                when (val type = type()) {
+                    is Action.Refresh -> type.flow.refreshStateChanges(
+                        tasksRepository = tasksRepository
+                    )
+                }
+            }
+        )
+    }
+)
+
+private fun loadStateChanges(
+    tasksRepository: TasksRepository
+): Flow<StateChange<StatisticsUiState>> =
+    tasksRepository.getTasksStream()
+        .map { Async.Success(it) }
+        .onStart<Async<Result<List<Task>>>> { emit(Async.Loading) }
+        .map { taskAsync ->
+            StateChange {
+                when (taskAsync) {
+                    Async.Loading -> {
+                        StatisticsUiState(isLoading = true, isEmpty = true)
+                    }
+                    is Async.Success -> {
+                        when (val result = taskAsync.data) {
+                            is Result.Success -> {
+                                val stats = getActiveAndCompletedStats(result.data)
+                                StatisticsUiState(
+                                    isEmpty = result.data.isEmpty(),
+                                    activeTasksPercent = stats.activeTasksPercent,
+                                    completedTasksPercent = stats.completedTasksPercent,
+                                    isLoading = false
+                                )
+                            }
+                            else -> StatisticsUiState(isLoading = false)
+                        }
+                    }
+                }
+            }
+        }
+
+private fun Flow<Action.Refresh>.refreshStateChanges(
+    tasksRepository: TasksRepository
+): Flow<StateChange<StatisticsUiState>> =
+    mapLatest {
+        tasksRepository.refreshTasks()
+        StateChange.identity()
+    }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailStateProducer.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailStateProducer.kt
@@ -1,0 +1,140 @@
+package com.example.android.architecture.blueprints.todoapp.taskdetail
+
+import androidx.lifecycle.SavedStateHandle
+import com.example.android.architecture.blueprints.todoapp.R
+import com.example.android.architecture.blueprints.todoapp.TodoDestinationsArgs
+import com.example.android.architecture.blueprints.todoapp.data.Result
+import com.example.android.architecture.blueprints.todoapp.data.Task
+import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository
+import com.example.android.architecture.blueprints.todoapp.util.Async
+import com.example.android.architecture.blueprints.todoapp.util.frp.StateChange
+import com.example.android.architecture.blueprints.todoapp.util.frp.stateProducer
+import com.example.android.architecture.blueprints.todoapp.util.frp.toStateChangeStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onStart
+
+sealed class Action {
+    object Refresh : Action()
+    object Delete : Action()
+    object SnackBarMessageShown : Action()
+    data class SetCompleted(val completed: Boolean) : Action()
+}
+
+fun taskDetailStateProducer(
+    scope: CoroutineScope,
+    tasksRepository: TasksRepository,
+    savedStateHandle: SavedStateHandle
+) = stateProducer<Action, TaskDetailUiState>(
+    scope = scope,
+    initialState = TaskDetailUiState(isLoading = true),
+    actionTransform = { actionStream ->
+        val taskId: String = savedStateHandle[TodoDestinationsArgs.TASK_ID_ARG]!!
+        merge(
+            loadStateChanges(
+                taskId = taskId,
+                tasksRepository = tasksRepository
+            ),
+            actionStream.toStateChangeStream {
+                when (val type = type()) {
+                    is Action.Refresh -> type.flow.refreshStateChanges(
+                        taskId = taskId,
+                        tasksRepository = tasksRepository
+                    )
+                    is Action.Delete -> type.flow.deleteStateChanges(
+                        taskId = taskId,
+                        tasksRepository = tasksRepository
+                    )
+                    is Action.SetCompleted -> type.flow.completionStateChanges(
+                        taskId = taskId,
+                        tasksRepository = tasksRepository
+                    )
+                    is Action.SnackBarMessageShown -> type.flow.snackbarMessageStateChanges()
+                }
+            }
+        )
+    }
+)
+
+private fun loadStateChanges(
+    taskId: String,
+    tasksRepository: TasksRepository
+): Flow<StateChange<TaskDetailUiState>> =
+    tasksRepository.getTaskStream(taskId)
+        .map { tasksResult ->
+            if (tasksResult is Result.Success) Async.Success(tasksResult.data)
+            else Async.Success(null)
+        }
+        .onStart<Async<Task?>> { emit(Async.Loading) }
+        .map { taskAsync ->
+            StateChange {
+                when (taskAsync) {
+                    Async.Loading -> copy(isLoading = true)
+                    is Async.Success -> copy(
+                        isLoading = false,
+                        task = taskAsync.data
+                    )
+                }
+            }
+        }
+
+private fun Flow<Action.Refresh>.refreshStateChanges(
+    taskId: String,
+    tasksRepository: TasksRepository
+): Flow<StateChange<TaskDetailUiState>> =
+    flatMapLatest {
+        flow {
+            emit(
+                StateChange {
+                    copy(isLoading = true)
+                }
+            )
+            tasksRepository.refreshTask(taskId)
+            emit(
+                StateChange {
+                    copy(isLoading = false)
+                }
+            )
+        }
+    }
+
+private fun Flow<Action.Delete>.deleteStateChanges(
+    taskId: String,
+    tasksRepository: TasksRepository
+): Flow<StateChange<TaskDetailUiState>> =
+    mapLatest {
+        tasksRepository.deleteTask(taskId)
+        StateChange {
+            copy(isTaskDeleted = true)
+        }
+    }
+
+private fun Flow<Action.SnackBarMessageShown>.snackbarMessageStateChanges(): Flow<StateChange<TaskDetailUiState>> =
+    mapLatest {
+        StateChange {
+            copy(userMessage = null)
+        }
+    }
+
+private fun Flow<Action.SetCompleted>.completionStateChanges(
+    taskId: String,
+    tasksRepository: TasksRepository
+): Flow<StateChange<TaskDetailUiState>> =
+    mapLatest { (completed) ->
+        if (completed) {
+            tasksRepository.completeTask(taskId)
+            StateChange {
+                copy(userMessage = R.string.task_marked_complete)
+            }
+        } else {
+            tasksRepository.activateTask(taskId)
+            StateChange {
+                copy(userMessage = R.string.task_marked_active)
+            }
+        }
+    }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksStateProducer.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksStateProducer.kt
@@ -1,0 +1,204 @@
+package com.example.android.architecture.blueprints.todoapp.tasks
+
+import androidx.lifecycle.SavedStateHandle
+import com.example.android.architecture.blueprints.todoapp.ADD_EDIT_RESULT_OK
+import com.example.android.architecture.blueprints.todoapp.DELETE_RESULT_OK
+import com.example.android.architecture.blueprints.todoapp.EDIT_RESULT_OK
+import com.example.android.architecture.blueprints.todoapp.R
+import com.example.android.architecture.blueprints.todoapp.data.Result
+import com.example.android.architecture.blueprints.todoapp.data.Task
+import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository
+import com.example.android.architecture.blueprints.todoapp.util.frp.StateChange
+import com.example.android.architecture.blueprints.todoapp.util.frp.stateProducer
+import com.example.android.architecture.blueprints.todoapp.util.frp.toStateChangeStream
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
+import kotlinx.coroutines.flow.merge
+
+sealed class Action {
+    object Refresh : Action()
+
+    object ClearCompletedTasks : Action()
+
+    data class ShowEditResultMessage(
+        val result: Int
+    ) : Action()
+
+    data class SetFilter(
+        val requestType: TasksFilterType
+    ) : Action()
+
+    data class SetTaskCompletion(
+        val task: Task,
+        val completed: Boolean
+    ) : Action()
+
+    object SnackBarMessageShown : Action()
+}
+
+fun tasksStateProducer(
+    scope: CoroutineScope,
+    tasksRepository: TasksRepository,
+    savedStateHandle: SavedStateHandle
+) = stateProducer<Action, TasksUiState>(
+    scope = scope,
+    initialState = TasksUiState(isLoading = true),
+    actionTransform = { actionStream ->
+        merge(
+            loadStateChanges(
+                tasksRepository = tasksRepository,
+                savedStateHandle = savedStateHandle
+            ),
+            actionStream.toStateChangeStream {
+                when (val type = type()) {
+                    is Action.ClearCompletedTasks -> type.flow.clearCompletedTasksStateChanges(
+                        tasksRepository = tasksRepository
+                    )
+                    is Action.Refresh -> type.flow.flatMapLatest {
+                        refreshStateChanges(tasksRepository = tasksRepository)
+                    }
+                    is Action.SetFilter -> type.flow.filterChangeStateChanges(
+                        savedStateHandle = savedStateHandle
+                    )
+                    is Action.SetTaskCompletion -> type.flow.taskCompletionStateChanges(
+                        tasksRepository = tasksRepository
+                    )
+                    is Action.ShowEditResultMessage -> type.flow.editResultMessageStateChanges()
+                    is Action.SnackBarMessageShown -> type.flow.snackbarMessageStateChanges()
+                }
+            }
+        )
+    }
+)
+
+private fun loadStateChanges(
+    tasksRepository: TasksRepository,
+    savedStateHandle: SavedStateHandle
+): Flow<StateChange<TasksUiState>> =
+    savedStateHandle.getStateFlow(
+        key = TASKS_FILTER_SAVED_STATE_KEY,
+        initialValue = TasksFilterType.ALL_TASKS
+    )
+        .flatMapLatest { filteringType ->
+            tasksRepository.getTasksStream().map { tasksResult ->
+                if (tasksResult is Result.Success) StateChange {
+                    copy(
+                        isLoading = false,
+                        items = tasksResult.data.filter {
+                            when (filteringType) {
+                                TasksFilterType.ALL_TASKS -> true
+                                TasksFilterType.ACTIVE_TASKS -> it.isActive
+                                TasksFilterType.COMPLETED_TASKS -> it.isCompleted
+                            }
+                        },
+                        filteringUiInfo = filteringType.filteringUiInfo
+                    )
+                } else StateChange {
+                    copy(
+                        isLoading = false,
+                        items = emptyList(),
+                        userMessage = R.string.loading_tasks_error,
+                        filteringUiInfo = filteringType.filteringUiInfo
+                    )
+                }
+            }
+        }
+
+private fun Flow<Action.SetFilter>.filterChangeStateChanges(
+    savedStateHandle: SavedStateHandle
+): Flow<StateChange<TasksUiState>> =
+    distinctUntilChanged()
+        .mapLatest { (requestType) ->
+            // Write the request type to the savedState handle
+            savedStateHandle[TASKS_FILTER_SAVED_STATE_KEY] = requestType
+            // Handle the filter change upstream
+            StateChange.identity()
+        }
+
+private fun Flow<Action.ShowEditResultMessage>.editResultMessageStateChanges(): Flow<StateChange<TasksUiState>> =
+    mapLatest { (result) ->
+        StateChange {
+            copy(
+                userMessage = when (result) {
+                    EDIT_RESULT_OK -> R.string.successfully_saved_task_message
+                    ADD_EDIT_RESULT_OK -> R.string.successfully_added_task_message
+                    DELETE_RESULT_OK -> R.string.successfully_deleted_task_message
+                    else -> null
+                }
+            )
+        }
+    }
+
+private fun Flow<Action.SnackBarMessageShown>.snackbarMessageStateChanges(): Flow<StateChange<TasksUiState>> =
+    mapLatest {
+        StateChange {
+            copy(userMessage = null)
+        }
+    }
+
+private fun Flow<Action.SetTaskCompletion>.taskCompletionStateChanges(
+    tasksRepository: TasksRepository
+): Flow<StateChange<TasksUiState>> =
+    distinctUntilChanged()
+        .mapLatest { (task, completed) ->
+            if (completed) tasksRepository.completeTask(task)
+            else tasksRepository.activateTask(task)
+
+            StateChange {
+                copy(
+                    userMessage = when (completed) {
+                        true -> R.string.task_marked_complete
+                        false -> R.string.task_marked_active
+                    }
+                )
+            }
+        }
+
+private fun Flow<Action.ClearCompletedTasks>.clearCompletedTasksStateChanges(
+    tasksRepository: TasksRepository
+): Flow<StateChange<TasksUiState>> = flatMapLatest {
+    tasksRepository.clearCompletedTasks()
+
+    flow {
+        emit(
+            StateChange {
+                copy(userMessage = R.string.completed_tasks_cleared)
+            }
+        )
+        emitAll(
+            refreshStateChanges(
+                tasksRepository = tasksRepository
+            )
+        )
+    }
+}
+
+private fun refreshStateChanges(
+    tasksRepository: TasksRepository
+): Flow<StateChange<TasksUiState>> = flow {
+    emit(StateChange { copy(isLoading = true) })
+    tasksRepository.refreshTasks()
+    emit(StateChange { copy(isLoading = false) })
+}
+
+private val TasksFilterType.filteringUiInfo
+    get() = when (this) {
+        TasksFilterType.ALL_TASKS -> FilteringUiInfo(
+            R.string.label_all, R.string.no_tasks_all,
+            R.drawable.logo_no_fill
+        )
+        TasksFilterType.ACTIVE_TASKS -> FilteringUiInfo(
+            R.string.label_active, R.string.no_tasks_active,
+            R.drawable.ic_check_circle_96dp
+        )
+        TasksFilterType.COMPLETED_TASKS -> FilteringUiInfo(
+            R.string.label_completed, R.string.no_tasks_completed,
+            R.drawable.ic_verified_user_96dp
+        )
+    }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/frp/StateChangeStream.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/frp/StateChangeStream.kt
@@ -1,0 +1,123 @@
+package com.example.android.architecture.blueprints.todoapp.util.frp
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flatMapMerge
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.scan
+
+/**
+ * Class holding the context of the [Action] emitted that is being split out into
+ * a [StateChange] [Flow].
+ *
+ * Use typically involves invoking [type] to identify the [Action] stream being transformed, and
+ * subsequently invoking [flow] to perform a custom transformation on the split out [Flow].
+ */
+data class TransformationContext<Action : Any>(
+    private val type: Action,
+    val backing: Flow<Action>
+) {
+
+    /**
+     * A convenience for the backing [Flow] of the [Action] subtype  from the parent [Flow]
+     */
+    @Suppress("unused", "UNCHECKED_CAST")
+    inline val <reified Subtype : Action> Subtype.flow: Flow<Subtype>
+        get() = backing as Flow<Subtype>
+
+    /**
+     * the first [Action] of the specified type emitted from the parent [Flow]
+     */
+    fun type() = type
+}
+
+/**
+ * Transforms a [Flow] of [Action] to a [Flow] of [StateChange] of [State], allowing for finer grained
+ * transforms on subtypes of [Action]. This allows for certain actions to be processed differently
+ * than others. For example: a certain action may need to only cause changes on distinct
+ * emissions, whereas other actions may need to use more complex [Flow] transformations like
+ * [Flow.flatMapMerge] and so on.
+ *
+ *  [keySelector]: The mapping for the [Action] to the key used to identify it. This is useful
+ *  for nested class hierarchies. By default each distinct type will be split out, but if you want
+ *  to treat certain subtypes as one type, this lets you do that.
+ *
+ *  [transform]: a function for mapping independent [Flow]s of [Action] to [Flow]s of [State]
+ *  [StateChange]s
+ * @see [splitByType]
+ */
+fun <Action : Any, State : Any> Flow<Action>.toStateChangeStream(
+    keySelector: (Action) -> String = Any::defaultKeySelector,
+    // Ergonomic hack to simulate multiple receivers
+    transform: TransformationContext<Action>.() -> Flow<StateChange<State>>
+): Flow<StateChange<State>> = splitByType(
+    typeSelector = { it },
+    keySelector = keySelector,
+    transform = transform
+)
+
+/**
+ * Transforms a [Flow] of [Input] to a [Flow] of [Output] by splitting the original into [Flow]s
+ * of type [Selector]. Each independent [Flow] of the [Selector] type can then be transformed
+ * into a [Flow] of [Output].
+ *
+ * [typeSelector]: The mapping to the type the [Input] [Flow] should be split into
+ *
+ * [keySelector]: The mapping to the [Selector] to the key used to identify it. This is useful
+ * for nested class hierarchies. By default each distinct type will be split out, but if you want
+ * to treat certain subtypes as one type, this lets you do that.
+ * [transform]: a function for mapping independent [Flow]s of [Selector] to [Flow]s of [Output]
+ */
+fun <Input : Any, Selector : Any, Output : Any> Flow<Input>.splitByType(
+    typeSelector: (Input) -> Selector,
+    keySelector: (Selector) -> String = Any::defaultKeySelector,
+    // Ergonomic hack to simulate multiple receivers
+    transform: TransformationContext<Selector>.() -> Flow<Output>
+): Flow<Output> =
+    channelFlow mutationFlow@{
+        val keysToFlowHolders = mutableMapOf<String, FlowHolder<Selector>>()
+        this@splitByType
+            .collect { item ->
+                val selected = typeSelector(item)
+                val flowKey = keySelector(selected)
+                when (val existingHolder = keysToFlowHolders[flowKey]) {
+                    null -> {
+                        val holder = FlowHolder(selected)
+                        keysToFlowHolders[flowKey] = holder
+                        val context = TransformationContext(selected, holder.exposedFlow)
+                        val mutationFlow = transform(context)
+                        channel.send(mutationFlow)
+                    }
+                    else -> {
+                        // Wait for downstream to be connected
+                        existingHolder.internalSharedFlow.subscriptionCount.first { it > 0 }
+                        existingHolder.internalSharedFlow.emit(selected)
+                    }
+                }
+            }
+    }
+        .flatMapMerge(
+            concurrency = Int.MAX_VALUE,
+            transform = { it }
+        )
+
+fun <State : Any> Flow<StateChange<State>>.reduceInto(initialState: State): Flow<State> =
+    scan(initialState) { state, mutation -> mutation.mutate(state) }
+
+/**
+ * Container for representing a [Flow] of a subtype of [Action] that has been split out from
+ * a [Flow] of [Action]
+ */
+private data class FlowHolder<Action>(
+    val firstEmission: Action,
+) {
+    val internalSharedFlow: MutableSharedFlow<Action> = MutableSharedFlow()
+    val exposedFlow: Flow<Action> = internalSharedFlow.onStart { emit(firstEmission) }
+}
+
+private fun Any.defaultKeySelector(): String = this::class.simpleName
+    ?: throw IllegalArgumentException(
+        "Only well defined classes can be split or specify a different key selector"
+    )

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/frp/StateProducer.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/frp/StateProducer.kt
@@ -1,0 +1,89 @@
+package com.example.android.architecture.blueprints.todoapp.util.frp
+
+import com.example.android.architecture.blueprints.todoapp.util.WhileUiSubscribed
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Interface for a type that produces a [StateFlow] of [State] by processing [Action]
+ */
+interface StateProducer<Action : Any, State : Any> {
+    val process: (Action) -> Unit
+
+    val state: StateFlow<State>
+}
+
+/**
+ * Data class holding a change transform for a some state [T].
+ */
+data class StateChange<T : Any>(
+    val mutate: T.() -> T
+) {
+    companion object {
+        /**
+         * Identity state change function; semantically a no op [StateChange]
+         */
+        fun <T : Any> identity(): StateChange<T> = StateChange { this }
+    }
+}
+
+/**
+ * Defines a [StateProducer] to convert a [Flow] of [Action] into a [StateFlow] of [State].
+ *
+ * [scope]: The [CoroutineScope] for the resulting [StateFlow]. Any [Action]s sent if there are no
+ * subscribers to the output [StateFlow] will suspend until there is as least one subscriber.
+ *
+ * [initialState]: The seed state for the resulting [StateFlow].
+ *
+ * [started]: Semantics for the "hotness" of the output [StateFlow] @see [Flow.stateIn]
+ *
+ * [stateTransform]: Further transformations o be applied to the output [StateFlow]
+ *
+ * [actionTransform]: Defines the transformations to the [Action] [Flow] to create [StateChange]s
+ * of state that will be reduced into the [initialState]. This is often achieved through the
+ * [toStateChangeStream] [Flow] extension function.
+ */
+fun <Action : Any, State : Any> stateProducer(
+    scope: CoroutineScope,
+    initialState: State,
+    started: SharingStarted = WhileUiSubscribed,
+    stateTransform: (Flow<State>) -> Flow<State> = { it },
+    actionTransform: (Flow<Action>) -> Flow<StateChange<State>>
+): StateProducer<Action, State> = object : StateProducer<Action, State> {
+    var seed = initialState
+    val actions = MutableSharedFlow<Action>()
+
+    override val state: StateFlow<State> =
+        stateTransform(
+            flow {
+                // Seed the reduction with the last produced state
+                emitAll(
+                    actionTransform(actions)
+                        .reduceInto(seed)
+                        .onEach(::seed::set)
+                )
+            }
+        )
+            .stateIn(
+                scope = scope,
+                started = started,
+                initialValue = initialState
+            )
+
+    override val process: (Action) -> Unit = { action ->
+        scope.launch {
+            // Suspend till downstream is connected
+            actions.subscriptionCount.first { it > 0 }
+            actions.emit(action)
+        }
+    }
+}


### PR DESCRIPTION
An experimental branch for functional reactive state production based on the [stateflow branch](https://github.com/android/architecture-samples/tree/stateflow).

It offers feature parity with the existing branch and tries to establish some core FRP state production concepts:

* Idiomatically functional: All inputs are eventually reduced into the UI state
* No side effects: all changes to state must be modeled in the stream
* Restricted UI state visibility: The state production pipeline cannot read the UI state until is ready to make changes to it
* Well defined inputs: All information required to process an action must be present at the input of the action