### PR TITLE
UDF experiment for producing state by merging flows

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -138,6 +138,7 @@ dependencies {
     testImplementation "androidx.test.espresso:espresso-intents:$espressoVersion"
     testImplementation "com.google.truth:truth:$truthVersion"
     testImplementation "androidx.compose.ui:ui-test-junit4:$composeVersion"
+    testImplementation "app.cash.turbine:turbine:$turbineVersion"
 
     // JVM tests - Hilt
     testImplementation "com.google.dagger:hilt-android-testing:$hiltVersion"

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.kt
@@ -24,12 +24,14 @@ import com.example.android.architecture.blueprints.todoapp.TodoDestinationsArgs
 import com.example.android.architecture.blueprints.todoapp.data.Result.Success
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository
+import com.example.android.architecture.blueprints.todoapp.util.Mutation
+import com.example.android.architecture.blueprints.todoapp.util.StateProducer
+import com.example.android.architecture.blueprints.todoapp.util.mutation
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
+import kotlinx.coroutines.flow.emptyFlow
+import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 /**
@@ -55,25 +57,23 @@ class AddEditTaskViewModel @Inject constructor(
 
     private val taskId: String? = savedStateHandle[TodoDestinationsArgs.TASK_ID_ARG]
 
-    // A MutableStateFlow needs to be created in this ViewModel. The source of truth of the current
-    // editable Task is the ViewModel, we need to mutate the UI state directly in methods such as
-    // `updateTitle` or `updateDescription`
-    private val _uiState = MutableStateFlow(AddEditTaskUiState())
-    val uiState: StateFlow<AddEditTaskUiState> = _uiState.asStateFlow()
+    private val stateProducer = StateProducer(
+        scope = viewModelScope,
+        initial = AddEditTaskUiState(),
+        mutationFlows = listOf(
+            loadStateChanges(taskId),
+        )
+    )
 
-    init {
-        if (taskId != null) {
-            loadTask(taskId)
-        }
-    }
+    val uiState: StateFlow<AddEditTaskUiState> = stateProducer.state
 
     // Called when clicking on fab.
-    fun saveTask() {
+    fun saveTask() = stateProducer.launch {
         if (uiState.value.title.isEmpty() || uiState.value.description.isEmpty()) {
-            _uiState.update {
-                it.copy(userMessage = R.string.empty_task_message)
+            setState {
+                copy(userMessage = R.string.empty_task_message)
             }
-            return
+            return@launch
         }
 
         if (taskId == null) {
@@ -83,72 +83,72 @@ class AddEditTaskViewModel @Inject constructor(
         }
     }
 
-    fun snackbarMessageShown() {
-        _uiState.update {
-            it.copy(userMessage = null)
+    fun snackbarMessageShown() = stateProducer.launch {
+        setState {
+            copy(userMessage = null)
         }
     }
 
-    fun updateTitle(newTitle: String) {
-        _uiState.update {
-            it.copy(title = newTitle)
+    fun updateTitle(newTitle: String) = stateProducer.launch {
+        setState {
+            copy(title = newTitle)
         }
     }
 
-    fun updateDescription(newDescription: String) {
-        _uiState.update {
-            it.copy(description = newDescription)
+    fun updateDescription(newDescription: String) = stateProducer.launch {
+        setState {
+            copy(description = newDescription)
         }
     }
 
-    private fun createNewTask() = viewModelScope.launch {
+    private fun createNewTask() = stateProducer.launch {
         val newTask = Task(uiState.value.title, uiState.value.description)
         tasksRepository.saveTask(newTask)
-        _uiState.update {
-            it.copy(isTaskSaved = true)
+        setState {
+            copy(isTaskSaved = true)
         }
     }
 
-    private fun updateTask() {
+    private fun updateTask() = stateProducer.launch {
         if (taskId == null) {
             throw RuntimeException("updateTask() was called but task is new.")
         }
-        viewModelScope.launch {
-            val updatedTask = Task(
-                title = uiState.value.title,
-                description = uiState.value.description,
-                isCompleted = uiState.value.isTaskCompleted,
-                id = taskId
-            )
-            tasksRepository.saveTask(updatedTask)
-            _uiState.update {
-                it.copy(isTaskSaved = true)
-            }
+        val updatedTask = Task(
+            title = uiState.value.title,
+            description = uiState.value.description,
+            isCompleted = uiState.value.isTaskCompleted,
+            id = taskId
+        )
+        tasksRepository.saveTask(updatedTask)
+        setState {
+            copy(isTaskSaved = true)
         }
     }
 
-    private fun loadTask(taskId: String) {
-        _uiState.update {
-            it.copy(isLoading = true)
-        }
-        viewModelScope.launch {
+    private fun loadStateChanges(taskId: String?): Flow<Mutation<AddEditTaskUiState>> =
+        if (taskId == null) emptyFlow()
+        else flow {
+            emit(
+                mutation {
+                    copy(isLoading = true)
+                }
+            )
             tasksRepository.getTask(taskId).let { result ->
-                if (result is Success) {
-                    val task = result.data
-                    _uiState.update {
-                        it.copy(
+                if (result is Success) emit(
+                    mutation {
+                        val task = result.data
+                        copy(
                             title = task.title,
                             description = task.description,
                             isTaskCompleted = task.isCompleted,
                             isLoading = false
                         )
                     }
-                } else {
-                    _uiState.update {
-                        it.copy(isLoading = false)
+                ) else emit(
+                    mutation {
+                        copy(isLoading = false)
                     }
-                }
+                )
             }
         }
-    }
 }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.kt
@@ -23,13 +23,14 @@ import com.example.android.architecture.blueprints.todoapp.data.Result.Success
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository
 import com.example.android.architecture.blueprints.todoapp.util.Async
-import com.example.android.architecture.blueprints.todoapp.util.WhileUiSubscribed
+import com.example.android.architecture.blueprints.todoapp.util.Mutation
+import com.example.android.architecture.blueprints.todoapp.util.StateProducer
+import com.example.android.architecture.blueprints.todoapp.util.mutation
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -50,40 +51,46 @@ class StatisticsViewModel @Inject constructor(
     private val tasksRepository: TasksRepository
 ) : ViewModel() {
 
-    val uiState: StateFlow<StatisticsUiState> =
-        tasksRepository.getTasksStream()
-            .map { Async.Success(it) }
-            .onStart<Async<Result<List<Task>>>> { emit(Async.Loading) }
-            .map { taskAsync -> produceStatisticsUiState(taskAsync) }
-            .stateIn(
-                scope = viewModelScope,
-                started = WhileUiSubscribed,
-                initialValue = StatisticsUiState(isLoading = true)
-            )
+    private val loadStateChanges = tasksRepository.getTasksStream()
+        .map { Async.Success(it) }
+        .onStart<Async<Result<List<Task>>>> { emit(Async.Loading) }
+        .loadStateChanges()
 
-    fun refresh() {
-        viewModelScope.launch {
-            tasksRepository.refreshTasks()
-        }
+    private val stateProducer = StateProducer(
+        scope = viewModelScope,
+        initial = StatisticsUiState(isLoading = true),
+        mutationFlows = listOf(
+            loadStateChanges
+        )
+    )
+
+    val uiState = stateProducer.state
+
+    fun refresh() = stateProducer.launch {
+        tasksRepository.refreshTasks()
     }
 
-    private fun produceStatisticsUiState(taskLoad: Async<Result<List<Task>>>) =
-        when (taskLoad) {
-            Async.Loading -> {
-                StatisticsUiState(isLoading = true, isEmpty = true)
-            }
-            is Async.Success -> {
-                when (val result = taskLoad.data) {
-                    is Success -> {
-                        val stats = getActiveAndCompletedStats(result.data)
-                        StatisticsUiState(
-                            isEmpty = result.data.isEmpty(),
-                            activeTasksPercent = stats.activeTasksPercent,
-                            completedTasksPercent = stats.completedTasksPercent,
-                            isLoading = false
-                        )
+    private fun Flow<Async<Result<List<Task>>>>.loadStateChanges(): Flow<Mutation<StatisticsUiState>> =
+        mapLatest { taskLoad ->
+            mutation {
+                when (taskLoad) {
+                    Async.Loading -> {
+                        copy(isLoading = true, isEmpty = true)
                     }
-                    else -> StatisticsUiState(isLoading = false)
+                    is Async.Success -> {
+                        when (val result = taskLoad.data) {
+                            is Success -> {
+                                val stats = getActiveAndCompletedStats(result.data)
+                                copy(
+                                    isEmpty = result.data.isEmpty(),
+                                    activeTasksPercent = stats.activeTasksPercent,
+                                    completedTasksPercent = stats.completedTasksPercent,
+                                    isLoading = false
+                                )
+                            }
+                            else -> copy(isLoading = false)
+                        }
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
@@ -25,15 +25,15 @@ import com.example.android.architecture.blueprints.todoapp.data.Result.Success
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksRepository
 import com.example.android.architecture.blueprints.todoapp.util.Async
-import com.example.android.architecture.blueprints.todoapp.util.WhileUiSubscribed
+import com.example.android.architecture.blueprints.todoapp.util.Mutation
+import com.example.android.architecture.blueprints.todoapp.util.StateProducer
+import com.example.android.architecture.blueprints.todoapp.util.mutation
+import com.example.android.architecture.blueprints.todoapp.util.plus
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapLatest
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 /**
@@ -57,73 +57,72 @@ class TaskDetailViewModel @Inject constructor(
 
     val taskId: String = savedStateHandle[TodoDestinationsArgs.TASK_ID_ARG]!!
 
-    private val _userMessage: MutableStateFlow<Int?> = MutableStateFlow(null)
-    private val _isLoading = MutableStateFlow(false)
-    private val _isTaskDeleted = MutableStateFlow(false)
-    private val _taskAsync = tasksRepository.getTaskStream(taskId)
+    private val loadStateChanges = tasksRepository.getTaskStream(taskId)
         .map { handleResult(it) }
         .onStart { emit(Async.Loading) }
+        .loadStateChanges()
 
-    val uiState: StateFlow<TaskDetailUiState> = combine(
-        _userMessage, _isLoading, _isTaskDeleted, _taskAsync
-    ) { userMessage, isLoading, isTaskDeleted, taskAsync ->
-        when (taskAsync) {
-            Async.Loading -> {
-                TaskDetailUiState(isLoading = true)
-            }
-            is Async.Success -> {
-                TaskDetailUiState(
-                    task = taskAsync.data,
-                    isLoading = isLoading,
-                    userMessage = userMessage,
-                    isTaskDeleted = isTaskDeleted
-                )
-            }
-        }
-    }
-        .stateIn(
-            scope = viewModelScope,
-            started = WhileUiSubscribed,
-            initialValue = TaskDetailUiState(isLoading = true)
+    private val stateProducer = StateProducer(
+        scope = viewModelScope,
+        initial = TaskDetailUiState(isLoading = true),
+        mutationFlows = listOf(
+            loadStateChanges,
         )
+    )
 
-    fun deleteTask() = viewModelScope.launch {
+    val uiState = stateProducer.state
+
+    fun deleteTask() = stateProducer.launch {
         tasksRepository.deleteTask(taskId)
-        _isTaskDeleted.value = true
+        setState { copy(isTaskDeleted = true) }
     }
 
-    fun setCompleted(completed: Boolean) = viewModelScope.launch {
+    fun setCompleted(completed: Boolean) = stateProducer.launch {
         val task = uiState.value.task ?: return@launch
         if (completed) {
             tasksRepository.completeTask(task)
-            showSnackbarMessage(R.string.task_marked_complete)
+            setState(snackBarMutation(R.string.task_marked_complete))
         } else {
             tasksRepository.activateTask(task)
-            showSnackbarMessage(R.string.task_marked_active)
+            setState(snackBarMutation(R.string.task_marked_active))
         }
     }
 
-    fun refresh() {
-        _isLoading.value = true
-        viewModelScope.launch {
-            tasksRepository.refreshTask(taskId)
-            _isLoading.value = false
-        }
+    fun refresh() = stateProducer.launch {
+        setState { copy(isLoading = true) }
+        tasksRepository.refreshTask(taskId)
+        setState { copy(isLoading = false) }
     }
 
-    fun snackbarMessageShown() {
-        _userMessage.value = null
+    fun snackbarMessageShown() = stateProducer.launch {
+        setState { copy(isLoading = false) }
     }
 
-    private fun showSnackbarMessage(message: Int) {
-        _userMessage.value = message
+    private fun snackBarMutation(message: Int) = mutation<TaskDetailUiState> {
+        copy(userMessage = message)
     }
 
     private fun handleResult(tasksResult: Result<Task>): Async<Task?> =
         if (tasksResult is Success) {
             Async.Success(tasksResult.data)
         } else {
-            showSnackbarMessage(R.string.loading_tasks_error)
             Async.Success(null)
+        }
+
+    private fun Flow<Async<Task?>>.loadStateChanges(): Flow<Mutation<TaskDetailUiState>> =
+        mapLatest { tasksResult: Async<Task?> ->
+            when (tasksResult) {
+                Async.Loading -> mutation {
+                    copy(isLoading = true)
+                }
+                is Async.Success -> when (val task = tasksResult.data) {
+                    null -> snackBarMutation(R.string.loading_tasks_error) + mutation {
+                        copy(task = null, isLoading = false)
+                    }
+                    else -> mutation {
+                        copy(task = task, isLoading = false)
+                    }
+                }
+            }
         }
 }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/StateProduction.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/StateProduction.kt
@@ -1,0 +1,103 @@
+package com.example.android.architecture.blueprints.todoapp.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.flow.scan
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/**
+ * Definition of a unit of change for a State.
+ */
+typealias Mutation<State> = State.() -> State
+
+/**
+ * Syntactic sugar for creating a [Mutation]
+ */
+fun <State> mutation(mutation: State.() -> State): Mutation<State> = mutation
+
+object Mutations {
+    /**
+     * Identity state change function; semantically a no op [Mutation]
+     */
+    fun <T : Any> identity(): Mutation<T> = mutation { this }
+}
+
+/**
+ * Combines two state changes into a single state change
+ */
+operator fun <T : Any> Mutation<T>.plus(other: Mutation<T>): Mutation<T> = inner@{
+    val result = this@plus(this@inner)
+    other.invoke(result)
+}
+
+/**
+ * Produces a [StateFlow] by merging [mutationFlows] and reducing them into an
+ * [initial] state
+ */
+fun <State : Any> CoroutineScope.produceState(
+    initial: State,
+    started: SharingStarted = WhileUiSubscribed,
+    mutationFlows: List<Flow<Mutation<State>>>
+): StateFlow<State> {
+    // Set the seed for the state
+    var seed = initial
+
+    // Use the flow factory function to capture the seed variable
+    return flow {
+        emitAll(
+            merge(*mutationFlows.toTypedArray())
+                // Reduce into the seed so if resubscribed, the last value of state is persisted
+                // when the flow pipeline is started again
+                .scan(seed) { state, mutation -> mutation(state) }
+                // Set seed after each emission
+                .onEach { seed = it }
+        )
+    }
+        .stateIn(
+            scope = this,
+            started = started,
+            initialValue = seed
+        )
+}
+
+/**
+ * Manges state production for [State]
+ */
+class StateProducer<State : Any>(
+    private val scope: CoroutineScope,
+    initial: State,
+    started: SharingStarted = WhileUiSubscribed,
+    mutationFlows: List<Flow<Mutation<State>>>
+) {
+    private val stateSetter = MutableSharedFlow<Mutation<State>>()
+
+    val state = scope.produceState(
+        initial = initial,
+        started = started,
+        mutationFlows = mutationFlows + stateSetter
+    )
+
+    suspend fun setState(mutation: Mutation<State>) = stateSetter.emit(mutation)
+
+    /**
+     * Runs [block] in [CoroutineScope] that has a [Job] as the child of the [Job] of [scope].
+     * This allows for the child [Job] to be passed a parameter in the [block] lambda allowing
+     * for cancelling the coroutine that runs [block].
+     */
+    fun launch(
+        block: suspend StateProducer<State>.() -> Unit
+    ) {
+        scope.launch {
+            block()
+        }
+    }
+}

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/util/StateProductionKtTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/util/StateProductionKtTest.kt
@@ -1,0 +1,136 @@
+package com.example.android.architecture.blueprints.todoapp.util
+
+import app.cash.turbine.test
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+private data class State(
+    val value: Int = 0
+)
+
+class StateProductionKtTest {
+
+    private val testDispatcher = UnconfinedTestDispatcher()
+    private lateinit var scope: CoroutineScope
+    private lateinit var eventStateChanges: MutableSharedFlow<Mutation<State>>
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        scope = TestScope(testDispatcher)
+        eventStateChanges = MutableSharedFlow()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun test_simple_state_production() = runTest {
+        val state = scope.produceState(
+            initial = State(),
+            mutationFlows = listOf(
+                eventStateChanges
+            )
+        )
+
+        state.test {
+            assertEquals(State(0), awaitItem())
+            eventStateChanges.emit { copy(value = value + 1) }
+            assertEquals(State(1), awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun test_state_production_persists_after_unsubscribing() = runTest {
+        val state = scope.produceState(
+            initial = State(),
+            started = SharingStarted.WhileSubscribed(),
+            mutationFlows = listOf(
+                eventStateChanges
+            )
+        )
+
+        // Subscribe the first time
+        state.test {
+            assertEquals(State(0), awaitItem())
+            eventStateChanges.emit { copy(value = value + 1) }
+            assertEquals(State(1), awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+
+        // Subscribe again. The state flow value should not be reset by the pipeline restarting
+        state.test {
+            assertEquals(State(1), awaitItem())
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun test_state_production_with_merged_flows() = runTest {
+        val state = scope.produceState(
+            initial = State(),
+            started = SharingStarted.WhileSubscribed(),
+            mutationFlows = listOf(
+                eventStateChanges,
+                flow {
+                    delay(1000)
+                    emit(mutation { copy(value = 3) })
+
+                    delay(1000)
+                    emit(mutation { copy(value = 7) })
+                }
+            )
+        )
+
+        state.test {
+            assertEquals(State(0), awaitItem())
+
+            advanceTimeBy(1200)
+            assertEquals(State(3), awaitItem())
+
+            advanceTimeBy(1200)
+            assertEquals(State(7), awaitItem())
+
+            eventStateChanges.emit { copy(value = 0) }
+            assertEquals(State(0), awaitItem())
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun test_state_change_addition() {
+        val additionmutation = mutation<State> {
+            copy(value = value + 1)
+        } +
+            mutation {
+                copy(value = value + 1)
+            } +
+            mutation {
+                copy(value = value + 1)
+            }
+
+        val state = additionmutation(State())
+
+        assertEquals(State(3), state)
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -78,4 +78,5 @@ ext {
     rulesVersion = '1.0.1'
     timberVersion = '4.7.1'
     truthVersion = '1.1.2'
+    turbineVersion = '0.8.0'
 }


### PR DESCRIPTION
Produces state by merging flows that carry functions that lazily modify the state.

This avoids the issues that can arise when combining flows:

* The limited arity of the `combine` function
* The difficulty of merging the effects of user actions into the state production pipeline

There are a probably a few rough edges, but it has an element of consistency across all ViewModels.

This change has the interesting side effect of only being able to push state changes only if there is an observer of UI state. If there is no observer of state, all pending pushes will suspend until an observer is present. This one of the reasons for adding Turbine as a test dependency.