### PR TITLE
Remove withContext, refactor duplicate methods

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/Task.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/Task.kt
@@ -32,10 +32,10 @@ import java.util.UUID
  */
 @Entity(tableName = "tasks")
 data class Task @JvmOverloads constructor(
-    @ColumnInfo(name = "title") var title: String = "",
-    @ColumnInfo(name = "description") var description: String = "",
-    @ColumnInfo(name = "completed") var isCompleted: Boolean = false,
-    @PrimaryKey @ColumnInfo(name = "entryid") var id: String = UUID.randomUUID().toString()
+    @ColumnInfo(name = "title") val title: String = "",
+    @ColumnInfo(name = "description") val description: String = "",
+    @ColumnInfo(name = "completed") val isCompleted: Boolean = false,
+    @PrimaryKey @ColumnInfo(name = "entryid") val id: String = UUID.randomUUID().toString()
 ) {
 
     val titleForList: String

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksDataSource.kt
@@ -38,11 +38,7 @@ interface TasksDataSource {
 
     suspend fun saveTask(task: Task)
 
-    suspend fun completeTask(task: Task)
-
     suspend fun completeTask(taskId: String)
-
-    suspend fun activateTask(task: Task)
 
     suspend fun activateTask(taskId: String)
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/TasksRepository.kt
@@ -38,11 +38,7 @@ interface TasksRepository {
 
     suspend fun saveTask(task: Task)
 
-    suspend fun completeTask(task: Task)
-
     suspend fun completeTask(taskId: String)
-
-    suspend fun activateTask(task: Task)
 
     suspend fun activateTask(taskId: String)
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSource.kt
@@ -18,16 +18,12 @@ package com.example.android.architecture.blueprints.todoapp.data.source.local
 
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 /**
  * Concrete implementation of a data source as a db.
  */
 class TasksLocalDataSource internal constructor(
-    private val tasksDao: TasksDao,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val tasksDao: TasksDao
 ) : TasksDataSource {
 
     override fun getTasksStream() = tasksDao.observeTasks()
@@ -42,43 +38,25 @@ class TasksLocalDataSource internal constructor(
         // NO-OP
     }
 
-    override suspend fun getTasks(): List<Task> = withContext(ioDispatcher) {
-        return@withContext tasksDao.getTasks()
-    }
+    override suspend fun getTasks(): List<Task> = tasksDao.getTasks()
 
-    override suspend fun getTask(taskId: String): Task? = withContext(ioDispatcher) {
-        return@withContext tasksDao.getTaskById(taskId)
-    }
+    override suspend fun getTask(taskId: String): Task? = tasksDao.getTaskById(taskId)
 
-    override suspend fun saveTask(task: Task) = withContext(ioDispatcher) {
-        tasksDao.insertTask(task)
-    }
+    override suspend fun saveTask(task: Task) = tasksDao.insertTask(task)
 
-    override suspend fun completeTask(task: Task) = withContext(ioDispatcher) {
-        tasksDao.updateCompleted(task.id, true)
-    }
-
-    override suspend fun completeTask(taskId: String) {
+    override suspend fun completeTask(taskId: String) =
         tasksDao.updateCompleted(taskId, true)
-    }
 
-    override suspend fun activateTask(task: Task) = withContext(ioDispatcher) {
-        tasksDao.updateCompleted(task.id, false)
-    }
-
-    override suspend fun activateTask(taskId: String) {
+    override suspend fun activateTask(taskId: String) =
         tasksDao.updateCompleted(taskId, false)
-    }
 
-    override suspend fun clearCompletedTasks() = withContext<Unit>(ioDispatcher) {
+    override suspend fun clearCompletedTasks() {
         tasksDao.deleteCompletedTasks()
     }
 
-    override suspend fun deleteAllTasks() = withContext(ioDispatcher) {
-        tasksDao.deleteTasks()
-    }
+    override suspend fun deleteAllTasks() = tasksDao.deleteTasks()
 
-    override suspend fun deleteTask(taskId: String) = withContext<Unit>(ioDispatcher) {
+    override suspend fun deleteTask(taskId: String) {
         tasksDao.deleteTaskById(taskId)
     }
 }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
@@ -81,14 +81,14 @@ object TasksRemoteDataSource : TasksDataSource {
     }
 
     override suspend fun completeTask(taskId: String) {
-        TASKS_SERVICE_DATA[taskId]?.apply {
-            isCompleted = true
+        TASKS_SERVICE_DATA[taskId]?.let {
+            saveTask(it.copy(isCompleted = true))
         }
     }
 
     override suspend fun activateTask(taskId: String) {
-        TASKS_SERVICE_DATA[taskId]?.apply {
-            isCompleted = false
+        TASKS_SERVICE_DATA[taskId]?.let {
+            saveTask(it.copy(isCompleted = true))
         }
     }
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksRemoteDataSource.kt
@@ -80,22 +80,16 @@ object TasksRemoteDataSource : TasksDataSource {
         TASKS_SERVICE_DATA[task.id] = task
     }
 
-    override suspend fun completeTask(task: Task) {
-        val completedTask = Task(task.title, task.description, true, task.id)
-        TASKS_SERVICE_DATA[task.id] = completedTask
-    }
-
     override suspend fun completeTask(taskId: String) {
-        // Not required for the remote data source
-    }
-
-    override suspend fun activateTask(task: Task) {
-        val activeTask = Task(task.title, task.description, false, task.id)
-        TASKS_SERVICE_DATA[task.id] = activeTask
+        TASKS_SERVICE_DATA[taskId]?.apply {
+            isCompleted = true
+        }
     }
 
     override suspend fun activateTask(taskId: String) {
-        // Not required for the remote data source
+        TASKS_SERVICE_DATA[taskId]?.apply {
+            isCompleted = false
+        }
     }
 
     override suspend fun clearCompletedTasks() {

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/di/DataModules.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/di/DataModules.kt
@@ -31,7 +31,6 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import javax.inject.Qualifier
 import javax.inject.Singleton
-import kotlinx.coroutines.CoroutineDispatcher
 
 @Qualifier
 @Retention(AnnotationRetention.RUNTIME)
@@ -50,9 +49,8 @@ object RepositoryModule {
     fun provideTasksRepository(
         @RemoteTasksDataSource remoteDataSource: TasksDataSource,
         @LocalTasksDataSource localDataSource: TasksDataSource,
-        @IoDispatcher ioDispatcher: CoroutineDispatcher
     ): TasksRepository {
-        return DefaultTasksRepository(remoteDataSource, localDataSource, ioDispatcher)
+        return DefaultTasksRepository(remoteDataSource, localDataSource)
     }
 }
 
@@ -69,10 +67,9 @@ object DataSourceModule {
     @LocalTasksDataSource
     @Provides
     fun provideTasksLocalDataSource(
-        database: ToDoDatabase,
-        @IoDispatcher ioDispatcher: CoroutineDispatcher
+        database: ToDoDatabase
     ): TasksDataSource {
-        return TasksLocalDataSource(database.taskDao(), ioDispatcher)
+        return TasksLocalDataSource(database.taskDao())
     }
 }
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
@@ -100,10 +100,10 @@ class TaskDetailViewModel @Inject constructor(
     fun setCompleted(completed: Boolean) = viewModelScope.launch {
         val task = uiState.value.task ?: return@launch
         if (completed) {
-            tasksRepository.completeTask(task)
+            tasksRepository.completeTask(task.id)
             showSnackbarMessage(R.string.task_marked_complete)
         } else {
-            tasksRepository.activateTask(task)
+            tasksRepository.activateTask(task.id)
             showSnackbarMessage(R.string.task_marked_active)
         }
     }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
@@ -113,10 +113,10 @@ class TasksViewModel @Inject constructor(
 
     fun completeTask(task: Task, completed: Boolean) = viewModelScope.launch {
         if (completed) {
-            tasksRepository.completeTask(task)
+            tasksRepository.completeTask(task.id)
             showSnackbarMessage(R.string.task_marked_complete)
         } else {
-            tasksRepository.activateTask(task)
+            tasksRepository.activateTask(task.id)
             showSnackbarMessage(R.string.task_marked_active)
         }
     }

--- a/app/src/sharedTest/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeRepository.kt
+++ b/app/src/sharedTest/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeRepository.kt
@@ -86,31 +86,20 @@ class FakeRepository : TasksRepository {
         }
     }
 
-    override suspend fun completeTask(task: Task) {
-        val completedTask = Task(task.title, task.description, true, task.id)
-        _savedTasks.update { tasks ->
-            val newTasks = LinkedHashMap<String, Task>(tasks)
-            newTasks[task.id] = completedTask
-            newTasks
-        }
-    }
-
     override suspend fun completeTask(taskId: String) {
-        // Not required for the remote data source.
-        throw NotImplementedError()
-    }
-
-    override suspend fun activateTask(task: Task) {
-        val activeTask = Task(task.title, task.description, false, task.id)
         _savedTasks.update { tasks ->
             val newTasks = LinkedHashMap<String, Task>(tasks)
-            newTasks[task.id] = activeTask
+            newTasks[taskId]?.apply { isCompleted = true }
             newTasks
         }
     }
 
     override suspend fun activateTask(taskId: String) {
-        throw NotImplementedError()
+        _savedTasks.update { tasks ->
+            val newTasks = LinkedHashMap<String, Task>(tasks)
+            newTasks[taskId]?.apply { isCompleted = false }
+            newTasks
+        }
     }
 
     override suspend fun clearCompletedTasks() {

--- a/app/src/sharedTest/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeRepository.kt
+++ b/app/src/sharedTest/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeRepository.kt
@@ -87,18 +87,14 @@ class FakeRepository : TasksRepository {
     }
 
     override suspend fun completeTask(taskId: String) {
-        _savedTasks.update { tasks ->
-            val newTasks = LinkedHashMap<String, Task>(tasks)
-            newTasks[taskId]?.apply { isCompleted = true }
-            newTasks
+        _savedTasks.value[taskId]?.let {
+            saveTask(it.copy(isCompleted = true))
         }
     }
 
     override suspend fun activateTask(taskId: String) {
-        _savedTasks.update { tasks ->
-            val newTasks = LinkedHashMap<String, Task>(tasks)
-            newTasks[taskId]?.apply { isCompleted = false }
-            newTasks
+        _savedTasks.value[taskId]?.let {
+            saveTask(it.copy(isCompleted = false))
         }
     }
 

--- a/app/src/sharedTest/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSourceTest.kt
+++ b/app/src/sharedTest/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TasksLocalDataSourceTest.kt
@@ -24,7 +24,6 @@ import androidx.test.filters.MediumTest
 import com.example.android.architecture.blueprints.todoapp.MainCoroutineRule
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.data.source.TasksDataSource
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.hamcrest.CoreMatchers.`is`
@@ -66,7 +65,7 @@ class TasksLocalDataSourceTest {
             .allowMainThreadQueries()
             .build()
 
-        localDataSource = TasksLocalDataSource(database.taskDao(), Dispatchers.Main)
+        localDataSource = TasksLocalDataSource(database.taskDao())
     }
 
     @After
@@ -96,7 +95,7 @@ class TasksLocalDataSourceTest {
         localDataSource.saveTask(newTask)
 
         // When completed in the persistent repository
-        localDataSource.completeTask(newTask)
+        localDataSource.completeTask(newTask.id)
         val task = localDataSource.getTask(newTask.id)
 
         // Then the task can be retrieved from the persistent repository and is complete
@@ -110,7 +109,7 @@ class TasksLocalDataSourceTest {
         val newTask = Task("Some title", "Some description", true)
         localDataSource.saveTask(newTask)
 
-        localDataSource.activateTask(newTask)
+        localDataSource.activateTask(newTask.id)
 
         // Then the task can be retrieved from the persistent repository and is active
         val task = localDataSource.getTask(newTask.id)
@@ -126,9 +125,9 @@ class TasksLocalDataSourceTest {
         val newTask2 = Task("title2")
         val newTask3 = Task("title3")
         localDataSource.saveTask(newTask1)
-        localDataSource.completeTask(newTask1)
+        localDataSource.completeTask(newTask1.id)
         localDataSource.saveTask(newTask2)
-        localDataSource.completeTask(newTask2)
+        localDataSource.completeTask(newTask2.id)
         localDataSource.saveTask(newTask3)
         // When completed tasks are cleared in the repository
         localDataSource.clearCompletedTasks()

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/FakeFailingTasksRemoteDataSource.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/FakeFailingTasksRemoteDataSource.kt
@@ -50,15 +50,7 @@ object FakeFailingTasksRemoteDataSource : TasksDataSource {
         TODO("not implemented")
     }
 
-    override suspend fun completeTask(task: Task) {
-        TODO("not implemented")
-    }
-
     override suspend fun completeTask(taskId: String) {
-        TODO("not implemented")
-    }
-
-    override suspend fun activateTask(task: Task) {
         TODO("not implemented")
     }
 

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/DefaultTasksRepositoryTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/DefaultTasksRepositoryTest.kt
@@ -19,7 +19,6 @@ package com.example.android.architecture.blueprints.todoapp.data.source
 import com.example.android.architecture.blueprints.todoapp.MainCoroutineRule
 import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
@@ -57,7 +56,7 @@ class DefaultTasksRepositoryTest {
         tasksLocalDataSource = FakeDataSource(localTasks.toMutableList())
         // Get a reference to the class under test
         tasksRepository = DefaultTasksRepository(
-            tasksRemoteDataSource, tasksLocalDataSource, Dispatchers.Main
+            tasksRemoteDataSource, tasksLocalDataSource
         )
     }
 
@@ -66,7 +65,7 @@ class DefaultTasksRepositoryTest {
     fun getTasks_emptyRepositoryAndUninitializedCache() = runTest {
         val emptySource = FakeDataSource()
         val tasksRepository = DefaultTasksRepository(
-            emptySource, emptySource, Dispatchers.Main
+            emptySource, emptySource
         )
 
         assertThat(tasksRepository.getTasks().size).isEqualTo(0)

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/DefaultTasksRepositoryTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/DefaultTasksRepositoryTest.kt
@@ -240,7 +240,7 @@ class DefaultTasksRepositoryTest {
 
     @Test
     fun clearCompletedTasks() = runTest {
-        val completedTask = task1.copy().apply { isCompleted = true }
+        val completedTask = task1.copy(isCompleted = true)
         tasksRemoteDataSource.tasks = mutableListOf(completedTask, task2)
         tasksRepository.clearCompletedTasks()
 

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeDataSource.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeDataSource.kt
@@ -28,16 +28,8 @@ class FakeDataSource(var tasks: MutableList<Task>? = mutableListOf()) : TasksDat
         tasks?.add(task)
     }
 
-    override suspend fun completeTask(task: Task) {
-        tasks?.firstOrNull { it.id == task.id }?.let { it.isCompleted = true }
-    }
-
     override suspend fun completeTask(taskId: String) {
         tasks?.firstOrNull { it.id == taskId }?.let { it.isCompleted = true }
-    }
-
-    override suspend fun activateTask(task: Task) {
-        tasks?.firstOrNull { it.id == task.id }?.let { it.isCompleted = false }
     }
 
     override suspend fun activateTask(taskId: String) {

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeDataSource.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeDataSource.kt
@@ -29,11 +29,17 @@ class FakeDataSource(var tasks: MutableList<Task>? = mutableListOf()) : TasksDat
     }
 
     override suspend fun completeTask(taskId: String) {
-        tasks?.firstOrNull { it.id == taskId }?.let { it.isCompleted = true }
+        tasks?.firstOrNull { it.id == taskId }?.let {
+            deleteTask(it.id)
+            saveTask(it.copy(isCompleted = true))
+        }
     }
 
     override suspend fun activateTask(taskId: String) {
-        tasks?.firstOrNull { it.id == taskId }?.let { it.isCompleted = false }
+        tasks?.firstOrNull { it.id == taskId }?.let {
+            deleteTask(it.id)
+            saveTask(it.copy(isCompleted = false))
+        }
     }
 
     override suspend fun clearCompletedTasks() {

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModelTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModelTest.kt
@@ -90,7 +90,8 @@ class TaskDetailViewModelTest {
 
     @Test
     fun activateTask() = runTest {
-        task.isCompleted = true
+        tasksRepository.deleteAllTasks()
+        tasksRepository.addTasks(task.copy(isCompleted = true))
 
         // Verify that the task was completed initially
         assertThat(tasksRepository.savedTasks.value[task.id]?.isCompleted).isTrue()


### PR DESCRIPTION
Here's what I've done and why: 

- Removed all instances of `withContext`. `withContext` requires the caller to know something about the execution of the enclosed method(s) (e.g. it is cpu or disk bound). In this case, these calls are redundant because the only I/O bound operations are handled by Room, which will already move those operations onto the I/O thread, so we don't need to be concerned with it.
- Removed the `completeTask(task: Task)` and `activateTask(task: Task)` methods in favour of using the existing `completeTask(taskId: String)` and `activateTask(taskId: String)`. This creates a smaller API surface which is more loosely coupled. 
- Refactored `Task` to be immutable. Having a mutable model is an anti-pattern as it allows callers to modify the model, which violates SSOT. 