### PR TITLE
Simplify the network data source

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTasksRepository.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTasksRepository.kt
@@ -81,26 +81,6 @@ class DefaultTasksRepository(
         loadTasksFromNetwork()
     }
 
-    private suspend fun loadTasksFromNetwork() {
-        withContext(coroutineDispatcher) {
-            val remoteTasks = tasksNetworkDataSource.loadTasks()
-
-            // Real apps might want to do a proper sync, deleting, modifying or adding each task.
-            tasksDao.deleteTasks()
-            remoteTasks.forEach { task ->
-                tasksDao.insertTask(task.toTaskEntity())
-            }
-        }
-    }
-
-    private suspend fun saveTasksToNetwork() {
-        withContext(coroutineDispatcher) {
-            // Real apps may want to use a proper sync strategy here to avoid data conflicts.
-            val localTasks = tasksDao.getTasks()
-            tasksNetworkDataSource.saveTasks(localTasks.toNetworkModels())
-        }
-    }
-
     override fun getTaskStream(taskId: String): Flow<Task?> {
         return tasksDao.observeTaskById(taskId).map { it.toExternalModel() }
     }
@@ -141,5 +121,25 @@ class DefaultTasksRepository(
     override suspend fun deleteTask(taskId: String) {
         tasksDao.deleteTaskById(taskId)
         saveTasksToNetwork()
+    }
+
+    private suspend fun loadTasksFromNetwork() {
+        withContext(coroutineDispatcher) {
+            val remoteTasks = tasksNetworkDataSource.loadTasks()
+
+            // Real apps might want to do a proper sync, deleting, modifying or adding each task.
+            tasksDao.deleteTasks()
+            remoteTasks.forEach { task ->
+                tasksDao.insertTask(task.toTaskEntity())
+            }
+        }
+    }
+
+    private suspend fun saveTasksToNetwork() {
+        withContext(coroutineDispatcher) {
+            // Real apps may want to use a proper sync strategy here to avoid data conflicts.
+            val localTasks = tasksDao.getTasks()
+            tasksNetworkDataSource.saveTasks(localTasks.toNetworkModels())
+        }
     }
 }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTasksRepository.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTasksRepository.kt
@@ -129,16 +129,12 @@ class DefaultTasksRepository(
     }
 
     override suspend fun clearCompletedTasks() {
-        withContext(coroutineDispatcher) {
-            tasksDao.deleteCompletedTasks()
-        }
+        tasksDao.deleteCompletedTasks()
         saveTasksToNetwork()
     }
 
     override suspend fun deleteAllTasks() {
-        withContext(coroutineDispatcher) {
-            tasksDao.deleteTasks()
-        }
+        tasksDao.deleteTasks()
         saveTasksToNetwork()
     }
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/ModelMappingExt.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/ModelMappingExt.kt
@@ -77,6 +77,8 @@ fun LocalTask.toNetworkModel() = NetworkTask(
     status = if (isCompleted) { TaskStatus.COMPLETE } else { TaskStatus.ACTIVE }
 )
 
+fun List<LocalTask>.toNetworkModels() = map(LocalTask::toNetworkModel)
+
 // External to Network
 fun Task.toNetworkModel() = toLocalModel().toNetworkModel()
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/NetworkDataSource.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/NetworkDataSource.kt
@@ -26,17 +26,5 @@ interface NetworkDataSource {
 
     suspend fun loadTasks(): List<NetworkTask>
 
-    suspend fun getTask(taskId: String): NetworkTask?
-
-    suspend fun saveTask(task: NetworkTask)
-
-    suspend fun completeTask(taskId: String)
-
-    suspend fun activateTask(taskId: String)
-
-    suspend fun clearCompletedTasks()
-
-    suspend fun deleteAllTasks()
-
-    suspend fun deleteTask(taskId: String)
+    suspend fun saveTasks(tasks: List<NetworkTask>)
 }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksNetworkDataSource.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/remote/TasksNetworkDataSource.kt
@@ -49,44 +49,15 @@ object TasksNetworkDataSource : NetworkDataSource {
         return tasks
     }
 
-    override suspend fun getTask(taskId: String): NetworkTask? {
+    override suspend fun saveTasks(tasks: List<NetworkTask>) {
         // Simulate network by delaying the execution.
         delay(SERVICE_LATENCY_IN_MILLIS)
-        return TASKS_SERVICE_DATA[taskId]
+        TASKS_SERVICE_DATA.clear()
+        TASKS_SERVICE_DATA.putAll(tasks.associateBy(NetworkTask::id))
     }
 
     private fun addTask(id: String, title: String, shortDescription: String) {
         val newTask = NetworkTask(id = id, title = title, shortDescription = shortDescription)
         TASKS_SERVICE_DATA[newTask.id] = newTask
-    }
-
-    override suspend fun saveTask(task: NetworkTask) {
-        TASKS_SERVICE_DATA[task.id] = task
-    }
-
-    override suspend fun completeTask(taskId: String) {
-        TASKS_SERVICE_DATA[taskId]?.let {
-            saveTask(it.copy(status = TaskStatus.COMPLETE))
-        }
-    }
-
-    override suspend fun activateTask(taskId: String) {
-        TASKS_SERVICE_DATA[taskId]?.let {
-            saveTask(it.copy(status = TaskStatus.ACTIVE))
-        }
-    }
-
-    override suspend fun clearCompletedTasks() {
-        TASKS_SERVICE_DATA = TASKS_SERVICE_DATA.filterValues {
-            it.status == TaskStatus.COMPLETE
-        } as LinkedHashMap<String, NetworkTask>
-    }
-
-    override suspend fun deleteAllTasks() {
-        TASKS_SERVICE_DATA.clear()
-    }
-
-    override suspend fun deleteTask(taskId: String) {
-        TASKS_SERVICE_DATA.remove(taskId)
     }
 }

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/DefaultTasksRepositoryTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/source/DefaultTasksRepositoryTest.kt
@@ -248,9 +248,9 @@ class DefaultTasksRepositoryTest {
     @Test
     fun clearCompletedTasks() = runTest {
         val completedTask = task1.copy(isCompleted = true)
-        tasksNetworkDataSource.tasks = mutableListOf(
-            completedTask.toNetworkModel(),
-            task2.toNetworkModel()
+        tasksLocalDataSource.tasks = mutableListOf(
+            completedTask.toLocalModel(),
+            task2.toLocalModel()
         )
         tasksRepository.clearCompletedTasks()
 

--- a/shared-test/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeNetworkDataSource.kt
+++ b/shared-test/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/FakeNetworkDataSource.kt
@@ -17,42 +17,13 @@
 package com.example.android.architecture.blueprints.todoapp.data.source
 
 import com.example.android.architecture.blueprints.todoapp.data.source.remote.NetworkTask
-import com.example.android.architecture.blueprints.todoapp.data.source.remote.TaskStatus
 
 class FakeNetworkDataSource(
     var tasks: MutableList<NetworkTask>? = mutableListOf()
 ) : NetworkDataSource {
     override suspend fun loadTasks() = tasks ?: throw Exception("Task list is null")
 
-    override suspend fun getTask(taskId: String) = tasks?.firstOrNull { it.id == taskId }
-
-    override suspend fun saveTask(task: NetworkTask) {
-        tasks?.add(task)
-    }
-
-    override suspend fun completeTask(taskId: String) {
-        tasks?.firstOrNull { it.id == taskId }?.let {
-            deleteTask(it.id)
-            saveTask(it.copy(status = TaskStatus.COMPLETE))
-        }
-    }
-
-    override suspend fun activateTask(taskId: String) {
-        tasks?.firstOrNull { it.id == taskId }?.let {
-            deleteTask(it.id)
-            saveTask(it.copy(status = TaskStatus.ACTIVE))
-        }
-    }
-
-    override suspend fun clearCompletedTasks() {
-        tasks?.removeIf { it.status == TaskStatus.COMPLETE }
-    }
-
-    override suspend fun deleteAllTasks() {
-        tasks?.clear()
-    }
-
-    override suspend fun deleteTask(taskId: String) {
-        tasks?.removeIf { it.id == taskId }
+    override suspend fun saveTasks(tasks: List<NetworkTask>) {
+        this.tasks = tasks.toMutableList()
     }
 }


### PR DESCRIPTION
tl;dr the local data source is now the source of truth, the network data source has only 2 methods which load and save all data. 

One of the goals of this sample is to demonstrate how to deal with _different_ data sources but the `NetworkDataSource` interface was very similar to the local `TasksDao` interface. 

For this reason, I have simplified the `NetworkDataSource` interface to just 2 methods `loadTasks` and `saveTasks`, which load and save _all_ tasks respectively.

I've also changed the way that data synchronisation works inside `DefaultTasksRepository`: 

- When reading tasks they are obtained locally, unless `forceRefresh` is specified, in which case they are first obtained from the network data source
- When writing information they are written locally first, then written to the network data source

This is not a robust sync implementation. In a production app, if the remote write failed and a force refresh was performed the local data would be overwritten. But I think it's better than what we had before which was essentially random behaviour.

