### PR TITLE
Rename mapping functions

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTasksRepository.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTasksRepository.kt
@@ -141,7 +141,7 @@ class DefaultTasksRepository(
 
             tasksDao.deleteTasks()
             remoteTasks.forEach { task ->
-                tasksDao.insertTask(task.toTaskEntity())
+                tasksDao.insertTask(task.toLocalTask())
             }
         }
     }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTasksRepository.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTasksRepository.kt
@@ -41,7 +41,7 @@ class DefaultTasksRepository(
 
     override suspend fun createTask(title: String, description: String): Task {
         val task = Task(title = title, description = description)
-        tasksDao.insertTask(task.toLocalModel())
+        tasksDao.insertTask(task.toLocal())
         saveTasksToNetwork()
         return task
     }
@@ -52,7 +52,7 @@ class DefaultTasksRepository(
             description = description
         ) ?: throw Exception("Task (id $taskId) not found")
 
-        tasksDao.insertTask(task.toLocalModel())
+        tasksDao.insertTask(task.toLocal())
         saveTasksToNetwork()
     }
 
@@ -61,7 +61,7 @@ class DefaultTasksRepository(
             loadTasksFromNetwork()
         }
         return withContext(coroutineDispatcher) {
-            tasksDao.getTasks().toExternalModels()
+            tasksDao.getTasks().toExternal()
         }
     }
 
@@ -72,7 +72,7 @@ class DefaultTasksRepository(
     override fun getTasksStream(): Flow<List<Task>> {
         return tasksDao.observeTasks().map { tasks ->
             withContext(coroutineDispatcher) {
-                tasks.toExternalModels()
+                tasks.toExternal()
             }
         }
     }
@@ -82,7 +82,7 @@ class DefaultTasksRepository(
     }
 
     override fun getTaskStream(taskId: String): Flow<Task?> {
-        return tasksDao.observeTaskById(taskId).map { it.toExternalModel() }
+        return tasksDao.observeTaskById(taskId).map { it.toExternal() }
     }
 
     /**
@@ -95,7 +95,7 @@ class DefaultTasksRepository(
         if (forceUpdate) {
             loadTasksFromNetwork()
         }
-        return tasksDao.getTaskById(taskId)?.toExternalModel()
+        return tasksDao.getTaskById(taskId)?.toExternal()
     }
 
     override suspend fun completeTask(taskId: String) {
@@ -141,7 +141,7 @@ class DefaultTasksRepository(
 
             tasksDao.deleteTasks()
             remoteTasks.forEach { task ->
-                tasksDao.insertTask(task.toLocalTask())
+                tasksDao.insertTask(task.toLocal())
             }
         }
     }
@@ -149,7 +149,7 @@ class DefaultTasksRepository(
     private suspend fun saveTasksToNetwork() {
         withContext(coroutineDispatcher) {
             val localTasks = tasksDao.getTasks()
-            tasksNetworkDataSource.saveTasks(localTasks.toNetworkModels())
+            tasksNetworkDataSource.saveTasks(localTasks.toNetwork())
         }
     }
 }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/ModelMappingExt.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/ModelMappingExt.kt
@@ -35,17 +35,17 @@ import com.example.android.architecture.blueprints.todoapp.data.source.network.T
  */
 
 // External to local
-fun Task.toLocalModel() = LocalTask(
+fun Task.toLocal() = LocalTask(
     id = id,
     title = title,
     description = description,
     isCompleted = isCompleted,
 )
 
-fun List<Task>.toLocalModels() = map(Task::toLocalModel)
+fun List<Task>.toLocalModels() = map(Task::toLocal)
 
 // Local to External
-fun LocalTask.toExternalModel() = Task(
+fun LocalTask.toExternal() = Task(
     id = id,
     title = title,
     description = description,
@@ -56,10 +56,10 @@ fun LocalTask.toExternalModel() = Task(
 // Without this, type erasure will cause compiler errors because these methods will have the same
 // signature on the JVM.
 @JvmName("localTasksToTasks")
-fun List<LocalTask>.toExternalModels() = map(LocalTask::toExternalModel)
+fun List<LocalTask>.toExternal() = map(LocalTask::toExternal)
 
 // Network to Local
-fun NetworkTask.toLocalTask() = LocalTask(
+fun NetworkTask.toLocal() = LocalTask(
     id = id,
     title = title,
     description = shortDescription,
@@ -67,26 +67,26 @@ fun NetworkTask.toLocalTask() = LocalTask(
 )
 
 @JvmName("networkTasksToLocalTasks")
-fun List<NetworkTask>.toLocalTasks() = map(NetworkTask::toLocalTask)
+fun List<NetworkTask>.toLocalTasks() = map(NetworkTask::toLocal)
 
 // Local to Network
-fun LocalTask.toNetworkModel() = NetworkTask(
+fun LocalTask.toNetwork() = NetworkTask(
     id = id,
     title = title,
     shortDescription = description,
     status = if (isCompleted) { TaskStatus.COMPLETE } else { TaskStatus.ACTIVE }
 )
 
-fun List<LocalTask>.toNetworkModels() = map(LocalTask::toNetworkModel)
+fun List<LocalTask>.toNetwork() = map(LocalTask::toNetwork)
 
 // External to Network
-fun Task.toNetworkModel() = toLocalModel().toNetworkModel()
+fun Task.toNetwork() = toLocal().toNetwork()
 
 @JvmName("tasksToNetworkTasks")
-fun List<Task>.toNetworkModels() = map(Task::toNetworkModel)
+fun List<Task>.toNetwork() = map(Task::toNetwork)
 
 // Network to External
-fun NetworkTask.toExternalModel() = toLocalTask().toExternalModel()
+fun NetworkTask.toExternal() = toLocal().toExternal()
 
 @JvmName("networkTasksToTasks")
-fun List<NetworkTask>.toExternalModels() = map(NetworkTask::toExternalModel)
+fun List<NetworkTask>.toExternal() = map(NetworkTask::toExternal)

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/ModelMappingExt.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/ModelMappingExt.kt
@@ -24,13 +24,13 @@ import com.example.android.architecture.blueprints.todoapp.data.source.network.T
  * Data model mapping extension functions. There are three model types:
  *
  * - Task: External model exposed to other layers in the architecture.
- * Obtained using `toExternalModel`.
+ * Obtained using `toExternal`.
  *
  * - NetworkTask: Internal model used to represent a task from the network. Obtained using
- * `toNetworkModel`.
+ * `toNetwork`.
  *
  * - LocalTask: Internal model used to represent a task stored locally in a database. Obtained
- * using `toLocalModel`.
+ * using `toLocal`.
  *
  */
 
@@ -42,7 +42,7 @@ fun Task.toLocal() = LocalTask(
     isCompleted = isCompleted,
 )
 
-fun List<Task>.toLocalModels() = map(Task::toLocal)
+fun List<Task>.toLocal() = map(Task::toLocal)
 
 // Local to External
 fun LocalTask.toExternal() = Task(
@@ -55,7 +55,7 @@ fun LocalTask.toExternal() = Task(
 // Note: JvmName is used to provide a unique name for each extension function with the same name.
 // Without this, type erasure will cause compiler errors because these methods will have the same
 // signature on the JVM.
-@JvmName("localTasksToTasks")
+@JvmName("localToExternal")
 fun List<LocalTask>.toExternal() = map(LocalTask::toExternal)
 
 // Network to Local
@@ -66,8 +66,8 @@ fun NetworkTask.toLocal() = LocalTask(
     isCompleted = (status == TaskStatus.COMPLETE),
 )
 
-@JvmName("networkTasksToLocalTasks")
-fun List<NetworkTask>.toLocalTasks() = map(NetworkTask::toLocal)
+@JvmName("networkToLocal")
+fun List<NetworkTask>.toLocal() = map(NetworkTask::toLocal)
 
 // Local to Network
 fun LocalTask.toNetwork() = NetworkTask(
@@ -82,11 +82,11 @@ fun List<LocalTask>.toNetwork() = map(LocalTask::toNetwork)
 // External to Network
 fun Task.toNetwork() = toLocal().toNetwork()
 
-@JvmName("tasksToNetworkTasks")
+@JvmName("externalToNetwork")
 fun List<Task>.toNetwork() = map(Task::toNetwork)
 
 // Network to External
 fun NetworkTask.toExternal() = toLocal().toExternal()
 
-@JvmName("networkTasksToTasks")
+@JvmName("networkToExternal")
 fun List<NetworkTask>.toExternal() = map(NetworkTask::toExternal)

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/ModelMappingExt.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/ModelMappingExt.kt
@@ -55,19 +55,19 @@ fun LocalTask.toExternalModel() = Task(
 // Note: JvmName is used to provide a unique name for each extension function with the same name.
 // Without this, type erasure will cause compiler errors because these methods will have the same
 // signature on the JVM.
-@JvmName("taskEntitiesToExternalModels")
+@JvmName("localTasksToTasks")
 fun List<LocalTask>.toExternalModels() = map(LocalTask::toExternalModel)
 
 // Network to Local
-fun NetworkTask.toTaskEntity() = LocalTask(
+fun NetworkTask.toLocalTask() = LocalTask(
     id = id,
     title = title,
     description = shortDescription,
     isCompleted = (status == TaskStatus.COMPLETE),
 )
 
-@JvmName("networkTasksToTaskEntities")
-fun List<NetworkTask>.toTaskEntities() = map(NetworkTask::toTaskEntity)
+@JvmName("networkTasksToLocalTasks")
+fun List<NetworkTask>.toLocalTasks() = map(NetworkTask::toLocalTask)
 
 // Local to Network
 fun LocalTask.toNetworkModel() = NetworkTask(
@@ -86,7 +86,7 @@ fun Task.toNetworkModel() = toLocalModel().toNetworkModel()
 fun List<Task>.toNetworkModels() = map(Task::toNetworkModel)
 
 // Network to External
-fun NetworkTask.toExternalModel() = toTaskEntity().toExternalModel()
+fun NetworkTask.toExternalModel() = toLocalTask().toExternalModel()
 
 @JvmName("networkTasksToTasks")
 fun List<NetworkTask>.toExternalModels() = map(NetworkTask::toExternalModel)


### PR DESCRIPTION
Function names now match model names but without the "Model" suffix. This suffix added a lot of visual noise (aka smurf naming).  