### PR TITLE
Minor renaming of methods and classes

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,7 +25,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
-            android:name="com.example.android.architecture.blueprints.todoapp.TasksActivity"
+            android:name="com.example.android.architecture.blueprints.todoapp.TodoActivity"
             android:windowSoftInputMode="adjustResize"
             android:exported="true"
             android:theme="@style/AppTheme.OverlapSystemBar">

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/TodoActivity.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/TodoActivity.kt
@@ -26,7 +26,7 @@ import dagger.hilt.android.AndroidEntryPoint
  * Main activity for the todoapp
  */
 @AndroidEntryPoint
-class TasksActivity : ComponentActivity() {
+class TodoActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/TodoNavigation.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/TodoNavigation.kt
@@ -46,7 +46,7 @@ object TodoDestinationsArgs {
 }
 
 /**
- * Destinations used in the [TasksActivity]
+ * Destinations used in the [TodoActivity]
  */
 object TodoDestinations {
     const val TASKS_ROUTE = "$TASKS_SCREEN?$USER_MESSAGE_ARG={$USER_MESSAGE_ARG}"

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/di/DataModules.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/di/DataModules.kt
@@ -33,7 +33,7 @@ import javax.inject.Singleton
 
 @Qualifier
 @Retention(AnnotationRetention.RUNTIME)
-annotation class RemoteTasksDataSource
+annotation class NetworkTaskDataSource
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -41,8 +41,8 @@ object RepositoryModule {
 
     @Singleton
     @Provides
-    fun provideTasksRepository(
-        @RemoteTasksDataSource remoteDataSource: NetworkDataSource,
+    fun provideTaskRepository(
+        @NetworkTaskDataSource remoteDataSource: NetworkDataSource,
         database: ToDoDatabase,
     ): TaskRepository {
         return DefaultTaskRepository(remoteDataSource, database.taskDao())
@@ -54,9 +54,9 @@ object RepositoryModule {
 object DataSourceModule {
 
     @Singleton
-    @RemoteTasksDataSource
+    @NetworkTaskDataSource
     @Provides
-    fun provideTasksRemoteDataSource(): NetworkDataSource = TaskNetworkDataSource
+    fun provideTaskRemoteDataSource(): NetworkDataSource = TaskNetworkDataSource
 }
 
 @Module


### PR DESCRIPTION
- Change `TasksActivity` to `TodoActivity` since it better represents that the activity contains all views
- Remove pluralisation in hilt methods