### PR TITLE
Change createTest to return task ID

### DIFF
--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsScreenTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsScreenTest.kt
@@ -66,7 +66,7 @@ class StatisticsScreenTest {
         repository.apply {
             createTask("Title1", "Description1")
             createTask("Title2", "Description2").also {
-                completeTask(it.id)
+                completeTask(it)
             }
         }
 

--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailScreenTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailScreenTest.kt
@@ -27,7 +27,6 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import com.example.android.architecture.blueprints.todoapp.HiltTestActivity
-import com.example.android.architecture.blueprints.todoapp.data.Task
 import com.example.android.architecture.blueprints.todoapp.data.TaskRepository
 import com.google.accompanist.appcompattheme.AppCompatTheme
 import dagger.hilt.android.testing.HiltAndroidRule
@@ -66,13 +65,13 @@ class TaskDetailScreenTest {
     @Test
     fun activeTaskDetails_DisplayedInUi() = runTest {
         // GIVEN - Add active (incomplete) task to the DB
-        val activeTask = repository.createTask(
+        val activeTaskId = repository.createTask(
             title = "Active Task",
             description = "AndroidX Rocks"
         )
 
         // WHEN - Details screen is opened
-        setContent(activeTask)
+        setContent(activeTaskId)
 
         // THEN - Task details are displayed on the screen
         // make sure that the title/description are both shown and correct
@@ -85,11 +84,11 @@ class TaskDetailScreenTest {
     @Test
     fun completedTaskDetails_DisplayedInUi() = runTest {
         // GIVEN - Add completed task to the DB
-        val completedTask = repository.createTask("Completed Task", "AndroidX Rocks")
-        repository.completeTask(completedTask.id)
+        val completedTaskId = repository.createTask("Completed Task", "AndroidX Rocks")
+        repository.completeTask(completedTaskId)
 
         // WHEN - Details screen is opened
-        setContent(completedTask)
+        setContent(completedTaskId)
 
         // THEN - Task details are displayed on the screen
         // make sure that the title/description are both shown and correct
@@ -99,14 +98,14 @@ class TaskDetailScreenTest {
         composeTestRule.onNode(isToggleable()).assertIsOn()
     }
 
-    private fun setContent(activeTask: Task) {
+    private fun setContent(activeTaskId: String) {
         composeTestRule.setContent {
             AppCompatTheme {
                 Surface {
                     TaskDetailScreen(
                         viewModel = TaskDetailViewModel(
                             repository,
-                            SavedStateHandle(mapOf("taskId" to activeTask.id))
+                            SavedStateHandle(mapOf("taskId" to activeTaskId))
                         ),
                         onEditTask = { /*TODO*/ },
                         onBack = { },

--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.kt
@@ -99,7 +99,7 @@ class TasksScreenTest {
     @Test
     fun displayCompletedTask() = runTest {
         repository.apply {
-            createTask("TITLE1", "DESCRIPTION1").also { completeTask(it.id) }
+            createTask("TITLE1", "DESCRIPTION1").also { completeTask(it) }
         }
 
         setContent()
@@ -134,7 +134,7 @@ class TasksScreenTest {
     @Test
     fun markTaskAsActive() = runTest {
         repository.apply {
-            createTask("TITLE1", "DESCRIPTION1").also { completeTask(it.id) }
+            createTask("TITLE1", "DESCRIPTION1").also { completeTask(it) }
         }
 
         setContent()
@@ -156,7 +156,7 @@ class TasksScreenTest {
         // Add one active task and one completed task
         repository.apply {
             createTask("TITLE1", "DESCRIPTION1")
-            createTask("TITLE2", "DESCRIPTION2").also { completeTask(it.id) }
+            createTask("TITLE2", "DESCRIPTION2").also { completeTask(it) }
         }
 
         setContent()
@@ -173,7 +173,7 @@ class TasksScreenTest {
         repository.apply {
             createTask("TITLE1", "DESCRIPTION1")
             createTask("TITLE2", "DESCRIPTION2")
-            createTask("TITLE3", "DESCRIPTION3").also { completeTask(it.id) }
+            createTask("TITLE3", "DESCRIPTION3").also { completeTask(it) }
         }
 
         setContent()
@@ -190,8 +190,8 @@ class TasksScreenTest {
         // Add one active task and 2 completed tasks
         repository.apply {
             createTask("TITLE1", "DESCRIPTION1")
-            createTask("TITLE2", "DESCRIPTION2").also { completeTask(it.id) }
-            createTask("TITLE3", "DESCRIPTION3").also { completeTask(it.id) }
+            createTask("TITLE2", "DESCRIPTION2").also { completeTask(it) }
+            createTask("TITLE3", "DESCRIPTION3").also { completeTask(it) }
         }
 
         setContent()
@@ -208,7 +208,7 @@ class TasksScreenTest {
         // Add one active task and one completed task
         repository.apply {
             createTask("TITLE1", "DESCRIPTION1")
-            createTask("TITLE2", "DESCRIPTION2").also { completeTask(it.id) }
+            createTask("TITLE2", "DESCRIPTION2").also { completeTask(it) }
         }
 
         setContent()

--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksTest.kt
@@ -195,7 +195,7 @@ class TasksTest {
         // Add 1 completed task
         val taskTitle = "ACTIVE"
         repository.apply {
-            createTask(taskTitle, "DESCRIPTION").also { completeTask(it.id) }
+            createTask(taskTitle, "DESCRIPTION").also { completeTask(it) }
         }
 
         setContent()
@@ -249,7 +249,7 @@ class TasksTest {
         // Add 1 completed task
         val taskTitle = "COMP-ACT"
         repository.apply {
-            createTask(taskTitle, "DESCRIPTION").also { completeTask(it.id) }
+            createTask(taskTitle, "DESCRIPTION").also { completeTask(it) }
         }
 
         setContent()

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepository.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepository.kt
@@ -40,7 +40,7 @@ class DefaultTaskRepository(
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : TaskRepository {
 
-    override suspend fun createTask(title: String, description: String): Task {
+    override suspend fun createTask(title: String, description: String): String {
         // ID creation might be a complex operation so it's executed using the supplied
         // coroutine dispatcher
         val taskId = withContext(coroutineDispatcher) {
@@ -53,7 +53,7 @@ class DefaultTaskRepository(
         )
         taskDao.upsert(task.toLocal())
         saveTasksToNetwork()
-        return task
+        return taskId
     }
 
     override suspend fun updateTask(taskId: String, title: String, description: String) {

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/TaskRepository.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/TaskRepository.kt
@@ -35,7 +35,7 @@ interface TaskRepository {
 
     suspend fun refreshTask(taskId: String)
 
-    suspend fun createTask(title: String, description: String): Task
+    suspend fun createTask(title: String, description: String): String
 
     suspend fun updateTask(taskId: String, title: String, description: String)
 

--- a/shared-test/src/main/java/com/example/android/architecture/blueprints/todoapp/data/FakeTaskRepository.kt
+++ b/shared-test/src/main/java/com/example/android/architecture/blueprints/todoapp/data/FakeTaskRepository.kt
@@ -56,14 +56,12 @@ class FakeTaskRepository : TaskRepository {
         refreshTasks()
     }
 
-    override suspend fun createTask(title: String, description: String): Task {
-        return Task(
-            title = title,
-            description = description,
-            id = generateTaskId()
-        ).also {
+    override suspend fun createTask(title: String, description: String): String {
+        val taskId = generateTaskId()
+        Task(title = title, description = description, id = taskId).also {
             saveTask(it)
         }
+        return taskId
     }
 
     override fun getTasksStream(): Flow<List<Task>> = observableTasks


### PR DESCRIPTION
`createTask` now returns the newly created task ID as a `String`, rather than a whole `Task`. This encourages callers to use the `observe` methods to get access to the tasks over time. More reactive, less imperative.  

