### PR TITLE
Pull to refresh doesn't work when there are no tasks

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreen.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreen.kt
@@ -29,6 +29,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.Checkbox
 import androidx.compose.material.FloatingActionButton
 import androidx.compose.material.Icon
@@ -215,7 +217,9 @@ private fun TasksEmptyContent(
     modifier: Modifier = Modifier
 ) {
     Column(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState()),
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/ComposeUtils.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/util/ComposeUtils.kt
@@ -16,11 +16,15 @@
 
 package com.example.android.architecture.blueprints.todoapp.util
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.pullrefresh.PullRefreshIndicator
+import androidx.compose.material.pullrefresh.pullRefresh
+import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import com.google.accompanist.swiperefresh.SwipeRefresh
-import com.google.accompanist.swiperefresh.rememberSwipeRefreshState
 
 val primaryDarkColor: Color = Color(0xFF263238)
 
@@ -34,6 +38,7 @@ val primaryDarkColor: Color = Color(0xFF263238)
  * @param modifier the modifier to apply to this layout.
  * @param content (slot) the main content to show
  */
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun LoadingContent(
     loading: Boolean,
@@ -43,14 +48,13 @@ fun LoadingContent(
     modifier: Modifier = Modifier,
     content: @Composable () -> Unit
 ) {
-    if (empty) {
-        emptyContent()
-    } else {
-        SwipeRefresh(
-            state = rememberSwipeRefreshState(loading),
-            onRefresh = onRefresh,
-            modifier = modifier,
-            content = content,
-        )
+    val pullRefreshState = rememberPullRefreshState(loading, onRefresh)
+    Box(modifier = modifier.pullRefresh(pullRefreshState)) {
+        if (empty) {
+            emptyContent()
+        } else {
+            content()
+        }
+        PullRefreshIndicator(loading, pullRefreshState, Modifier.align(Alignment.TopCenter))
     }
 }


### PR DESCRIPTION
Why these changes are required ?

- Currently on the task list screen when the content is empty or no tasks, pull to refresh doesn't work(it is not shown at all after you swipe down vertically)
- Reason is the empty container shown doesn't  contain pull to refresh
- Exisiting _**SwipeRefresh**_ is deprecated


What changes are addressed ?

- Addressed the issue of showing a pull to refresh spinner both when the content is empty and not empty
- Migrated _**SwipeRefresh**_ to [PullRefreshIndicator](https://google.github.io/accompanist/swiperefresh/#migration) as suggested


[todo_test.webm](https://user-images.githubusercontent.com/61533235/227925807-daf4f8e4-b3d9-4e6a-93b5-b5128e3a0efd.webm)
