### PR TITLE
Minor tidy ups

### DIFF
--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TaskDaoTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TaskDaoTest.kt
@@ -35,15 +35,16 @@ class TaskDaoTest {
 
     // using an in-memory database because the information stored here disappears when the
     // process is killed
-    private val database = Room.inMemoryDatabaseBuilder(
-        getApplicationContext(),
-        ToDoDatabase::class.java
-    ).allowMainThreadQueries().build()
+    private lateinit var database: ToDoDatabase
 
-    // Ensure that we use an empty database for each test.
+    // Ensure that we use a new database for each test.
     @Before
-    fun initDb() = database.clearAllTables()
-
+    fun initDb() {
+        database = Room.inMemoryDatabaseBuilder(
+            getApplicationContext(),
+            ToDoDatabase::class.java
+        ).allowMainThreadQueries().build()
+    }
     @Test
     fun insertTaskAndGetById() = runTest {
         // GIVEN - insert a task

--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TaskDaoTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TaskDaoTest.kt
@@ -42,10 +42,6 @@ class TaskDaoTest {
         ToDoDatabase::class.java
     ).allowMainThreadQueries().build()
 
-    // Set the main coroutines dispatcher for unit testing.
-    @get:Rule
-    val mainCoroutineRule = MainCoroutineRule()
-
     // Ensure that we use an empty database for each test.
     @Before
     fun initDb() = database.clearAllTables()

--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TaskDaoTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TaskDaoTest.kt
@@ -20,13 +20,11 @@ import androidx.room.Room
 import androidx.test.core.app.ApplicationProvider.getApplicationContext
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.SmallTest
-import com.example.android.architecture.blueprints.todoapp.MainCoroutineRule
 import junit.framework.TestCase.assertEquals
 import junit.framework.TestCase.assertNotNull
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepository.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepository.kt
@@ -174,7 +174,10 @@ class DefaultTaskRepository @Inject constructor(
         scope.launch {
             try {
                 val localTasks = localDataSource.getAll()
-                networkDataSource.saveTasks(localTasks.toNetwork())
+                val networkTasks = withContext(dispatcher){
+                    localTasks.toNetwork()
+                }
+                networkDataSource.saveTasks(networkTasks)
             } catch (e: Exception) {
                 // In a real app you'd handle the exception e.g. by exposing a `networkStatus` flow
                 // to an app level UI state holder which could then display a Toast message.

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepository.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepository.kt
@@ -174,7 +174,7 @@ class DefaultTaskRepository @Inject constructor(
         scope.launch {
             try {
                 val localTasks = localDataSource.getAll()
-                val networkTasks = withContext(dispatcher){
+                val networkTasks = withContext(dispatcher) {
                     localTasks.toNetwork()
                 }
                 networkDataSource.saveTasks(networkTasks)

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TaskDao.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/TaskDao.kt
@@ -75,7 +75,7 @@ interface TaskDao {
      * @param tasks the tasks to be inserted or updated.
      */
     @Upsert
-    fun upsertAll(tasks: List<LocalTask>)
+    suspend fun upsertAll(tasks: List<LocalTask>)
 
     /**
      * Update the complete status of a task

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/network/TaskNetworkDataSource.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/network/TaskNetworkDataSource.kt
@@ -16,10 +16,10 @@
 
 package com.example.android.architecture.blueprints.todoapp.data.source.network
 
+import javax.inject.Inject
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import javax.inject.Inject
 
 class TaskNetworkDataSource @Inject constructor() : NetworkDataSource {
 

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/network/TaskNetworkDataSource.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/network/TaskNetworkDataSource.kt
@@ -16,48 +16,37 @@
 
 package com.example.android.architecture.blueprints.todoapp.data.source.network
 
-import javax.inject.Inject
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import javax.inject.Inject
 
-/**
- * Implementation of the data source that adds a latency simulating network.
- *
- */
 class TaskNetworkDataSource @Inject constructor() : NetworkDataSource {
 
-    private val SERVICE_LATENCY_IN_MILLIS = 2000L
-
-    private var TASK_SERVICE_DATA = LinkedHashMap<String, NetworkTask>(2)
-
-    init {
-        addTask(
+    // A mutex is used to ensure that reads and writes are thread-safe.
+    private val accessMutex = Mutex()
+    private var tasks = listOf(
+        NetworkTask(
             id = "PISA",
             title = "Build tower in Pisa",
             shortDescription = "Ground looks good, no foundation work required."
-        )
-        addTask(
+        ),
+        NetworkTask(
             id = "TACOMA",
             title = "Finish bridge in Tacoma",
             shortDescription = "Found awesome girders at half the cost!"
         )
-    }
+    )
 
-    override suspend fun loadTasks(): List<NetworkTask> {
-        // Simulate network by delaying the execution.
-        val tasks = TASK_SERVICE_DATA.values.toList()
+    override suspend fun loadTasks(): List<NetworkTask> = accessMutex.withLock {
         delay(SERVICE_LATENCY_IN_MILLIS)
         return tasks
     }
 
-    override suspend fun saveTasks(tasks: List<NetworkTask>) {
-        // Simulate network by delaying the execution.
+    override suspend fun saveTasks(newTasks: List<NetworkTask>) = accessMutex.withLock {
         delay(SERVICE_LATENCY_IN_MILLIS)
-        TASK_SERVICE_DATA.clear()
-        TASK_SERVICE_DATA.putAll(tasks.associateBy(NetworkTask::id))
-    }
-
-    private fun addTask(id: String, title: String, shortDescription: String) {
-        val newTask = NetworkTask(id = id, title = title, shortDescription = shortDescription)
-        TASK_SERVICE_DATA[newTask.id] = newTask
+        tasks = newTasks
     }
 }
+
+private const val SERVICE_LATENCY_IN_MILLIS = 2000L

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepositoryTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepositoryTest.kt
@@ -16,21 +16,15 @@
 
 package com.example.android.architecture.blueprints.todoapp.data
 
-import com.example.android.architecture.blueprints.todoapp.MainCoroutineRule
 import com.example.android.architecture.blueprints.todoapp.data.source.local.FakeTaskDao
 import com.example.android.architecture.blueprints.todoapp.data.source.network.FakeNetworkDataSource
 import com.google.common.truth.Truth.assertThat
 import junit.framework.TestCase.assertEquals
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestCoroutineScheduler
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 
 /**
@@ -60,7 +54,6 @@ class DefaultTaskRepositoryTest {
 
     // Class under test
     private lateinit var taskRepository: DefaultTaskRepository
-
 
     @ExperimentalCoroutinesApi
     @Before

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepositoryTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepositoryTest.kt
@@ -71,7 +71,7 @@ class DefaultTaskRepositoryTest {
 
     @ExperimentalCoroutinesApi
     @Test
-    fun getTasks_emptyRepositoryAndUninitializedCache() = runTest {
+    fun getTasks_emptyRepositoryAndUninitializedCache() = testScope.runTest {
         networkDataSource.tasks?.clear()
         localDataSource.deleteAll()
 
@@ -79,7 +79,7 @@ class DefaultTaskRepositoryTest {
     }
 
     @Test
-    fun getTasks_repositoryCachesAfterFirstApiCall() = runTest {
+    fun getTasks_repositoryCachesAfterFirstApiCall() = testScope.runTest {
         // Trigger the repository to load tasks from the remote data source
         val initial = taskRepository.getTasks(forceUpdate = true)
 
@@ -95,7 +95,7 @@ class DefaultTaskRepositoryTest {
     }
 
     @Test
-    fun getTasks_requestsAllTasksFromRemoteDataSource() = runTest {
+    fun getTasks_requestsAllTasksFromRemoteDataSource() = testScope.runTest {
         // When tasks are requested from the tasks repository
         val tasks = taskRepository.getTasks(true)
 
@@ -114,7 +114,7 @@ class DefaultTaskRepositoryTest {
     }
 
     @Test
-    fun getTasks_WithDirtyCache_tasksAreRetrievedFromRemote() = runTest {
+    fun getTasks_WithDirtyCache_tasksAreRetrievedFromRemote() = testScope.runTest {
         // First call returns from REMOTE
         val tasks = taskRepository.getTasks()
 
@@ -133,7 +133,7 @@ class DefaultTaskRepositoryTest {
     }
 
     @Test(expected = Exception::class)
-    fun getTasks_WithDirtyCache_remoteUnavailable_throwsException() = runTest {
+    fun getTasks_WithDirtyCache_remoteUnavailable_throwsException() = testScope.runTest {
         // Make remote data source unavailable
         networkDataSource.tasks = null
 
@@ -145,7 +145,7 @@ class DefaultTaskRepositoryTest {
 
     @Test
     fun getTasks_WithRemoteDataSourceUnavailable_tasksAreRetrievedFromLocal() =
-        runTest {
+        testScope.runTest {
             // When the remote data source is unavailable
             networkDataSource.tasks = null
 
@@ -154,7 +154,7 @@ class DefaultTaskRepositoryTest {
         }
 
     @Test(expected = Exception::class)
-    fun getTasks_WithBothDataSourcesUnavailable_throwsError() = runTest {
+    fun getTasks_WithBothDataSourcesUnavailable_throwsError() = testScope.runTest {
         // When both sources are unavailable
         networkDataSource.tasks = null
         localDataSource.tasks = null
@@ -164,7 +164,7 @@ class DefaultTaskRepositoryTest {
     }
 
     @Test
-    fun getTasks_refreshesLocalDataSource() = runTest {
+    fun getTasks_refreshesLocalDataSource() = testScope.runTest {
         // Forcing an update will fetch tasks from remote
         val expectedTasks = networkTasks.toExternal()
 
@@ -206,7 +206,7 @@ class DefaultTaskRepositoryTest {
     }
 
     @Test
-    fun getTask_repositoryCachesAfterFirstApiCall() = runTest {
+    fun getTask_repositoryCachesAfterFirstApiCall() = testScope.runTest {
         // Obtain a task from the local data source
         localDataSource = FakeTaskDao(mutableListOf(task1.toLocal()))
         val initial = taskRepository.getTask(task1.id)
@@ -222,7 +222,7 @@ class DefaultTaskRepositoryTest {
     }
 
     @Test
-    fun getTask_forceRefresh() = runTest {
+    fun getTask_forceRefresh() = testScope.runTest {
         // Trigger the repository to load data, which loads from remote and caches
         networkDataSource.tasks = mutableListOf(task1.toNetwork())
         val task1FirstTime = taskRepository.getTask(task1.id, forceUpdate = true)

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepositoryTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepositoryTest.kt
@@ -252,6 +252,7 @@ class DefaultTaskRepositoryTest {
         val completedTask = task1.copy(isCompleted = true)
         localDataSource.tasks = listOf(completedTask.toLocal(), task2.toLocal())
         tasksRepository.clearCompletedTasks()
+        advanceUntilIdle()
 
         val tasks = tasksRepository.getTasks(true)
 
@@ -281,6 +282,7 @@ class DefaultTaskRepositoryTest {
 
         // Delete first task
         tasksRepository.deleteTask(task1.id)
+        advanceUntilIdle()
 
         // Fetch data again
         val afterDeleteTasks = tasksRepository.getTasks(true)

--- a/shared-test/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/FakeTaskDao.kt
+++ b/shared-test/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/FakeTaskDao.kt
@@ -36,7 +36,7 @@ class FakeTaskDao(initialTasks: List<LocalTask>? = emptyList()) : TaskDao {
 
     override suspend fun getById(taskId: String): LocalTask? = _tasks?.get(taskId)
 
-    override fun upsertAll(tasks: List<LocalTask>) {
+    override suspend fun upsertAll(tasks: List<LocalTask>) {
         _tasks?.putAll(tasks.associateBy { it.id })
     }
 


### PR DESCRIPTION
Here's what I've done: 

- Added `suspend` to `upsertAll` (it was missed in a previous PR)
- Move the use of `withContext` to only wrap the mapping functions 
- Remove `MainCoroutineRule` from both `TaskDaoTest` and `DefaultTaskRepositoryTest`. In the latter, a `testScope` and `testDispatcher` are used to guarantee deterministic behaviour
- Remove pluralization `tasksRepository` to `taskRepository` in line with other recent changes