### PR TITLE
Migrate to KSP

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -18,6 +18,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
 
@@ -120,7 +121,7 @@ dependencies {
     // Architecture Components
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
-    kapt(libs.room.compiler)
+    ksp(libs.room.compiler)
     implementation(libs.androidx.lifecycle.runtimeCompose)
     implementation(libs.androidx.lifecycle.viewModelCompose)
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,5 +18,6 @@ plugins {
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kapt) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt) apply false
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,4 +19,5 @@ org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=1024m -XX:+HeapDumpOnOutOfMemoryErr
 android.enableJetifier=true
 android.useAndroidX=true
 kapt.incremental.apt=true
+ksp.incremental.apt=true
 org.gradle.unsafe.configuration-cache=true

--- a/shared-test/build.gradle.kts
+++ b/shared-test/build.gradle.kts
@@ -17,6 +17,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
 }
 
@@ -43,5 +44,5 @@ dependencies {
     // Room
     implementation(libs.room.runtime)
     implementation(libs.room.ktx)
-    kapt(libs.room.compiler)
+    ksp(libs.room.compiler)
 }


### PR DESCRIPTION
What Changes are done?
- Migrated room to use ksp

What Changes are not done as per requirement ?
- Couldn't migrate hilt to use ksp as the support for both Dagger and Hilt is not yet available. Please find the list of supported libraries on Android with support for KSP . Please check list of libraries supported for KSP on Android https://kotlinlang.org/docs/ksp-overview.html#supported-libraries

