### PR TITLE
Rename smurf named methods

### DIFF
--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskScreenTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskScreenTest.kt
@@ -106,7 +106,7 @@ class AddEditTaskScreenTest {
             .performClick()
 
         // THEN - Verify that the repository saved the task
-        val tasks = repository.getTasks(true)
+        val tasks = repository.getAll(true)
         assertEquals(1, tasks.size)
         assertEquals("title", tasks[0].title)
         assertEquals("description", tasks[0].description)

--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsScreenTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsScreenTest.kt
@@ -64,9 +64,9 @@ class StatisticsScreenTest {
     fun tasks_showsNonEmptyMessage() = runTest {
         // Given some tasks
         repository.apply {
-            createTask("Title1", "Description1")
-            createTask("Title2", "Description2").also {
-                completeTask(it)
+            create("Title1", "Description1")
+            create("Title2", "Description2").also {
+                complete(it)
             }
         }
 

--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailScreenTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailScreenTest.kt
@@ -65,7 +65,7 @@ class TaskDetailScreenTest {
     @Test
     fun activeTaskDetails_DisplayedInUi() = runTest {
         // GIVEN - Add active (incomplete) task to the DB
-        val activeTaskId = repository.createTask(
+        val activeTaskId = repository.create(
             title = "Active Task",
             description = "AndroidX Rocks"
         )
@@ -84,8 +84,8 @@ class TaskDetailScreenTest {
     @Test
     fun completedTaskDetails_DisplayedInUi() = runTest {
         // GIVEN - Add completed task to the DB
-        val completedTaskId = repository.createTask("Completed Task", "AndroidX Rocks")
-        repository.completeTask(completedTaskId)
+        val completedTaskId = repository.create("Completed Task", "AndroidX Rocks")
+        repository.complete(completedTaskId)
 
         // WHEN - Details screen is opened
         setContent(completedTaskId)

--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/AppNavigationTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/AppNavigationTest.kt
@@ -130,7 +130,7 @@ class AppNavigationTest {
     @Test
     fun taskDetailScreen_doubleUIBackButton() = runTest {
         val taskName = "UI <- button"
-        taskRepository.createTask(taskName, "Description")
+        taskRepository.create(taskName, "Description")
 
         setContent()
 
@@ -159,7 +159,7 @@ class AppNavigationTest {
     @Test
     fun taskDetailScreen_doubleBackButton() = runTest {
         val taskName = "Back button"
-        taskRepository.createTask(taskName, "Description")
+        taskRepository.create(taskName, "Description")
 
         setContent()
 

--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreenTest.kt
@@ -71,7 +71,7 @@ class TasksScreenTest {
     @Test
     fun displayTask_whenRepositoryHasData() = runTest {
         // GIVEN - One task already in the repository
-        repository.createTask("TITLE1", "DESCRIPTION1")
+        repository.create("TITLE1", "DESCRIPTION1")
 
         // WHEN - On startup
         setContent()
@@ -82,7 +82,7 @@ class TasksScreenTest {
 
     @Test
     fun displayActiveTask() = runTest {
-        repository.createTask("TITLE1", "DESCRIPTION1")
+        repository.create("TITLE1", "DESCRIPTION1")
 
         setContent()
 
@@ -99,7 +99,7 @@ class TasksScreenTest {
     @Test
     fun displayCompletedTask() = runTest {
         repository.apply {
-            createTask("TITLE1", "DESCRIPTION1").also { completeTask(it) }
+            create("TITLE1", "DESCRIPTION1").also { complete(it) }
         }
 
         setContent()
@@ -115,7 +115,7 @@ class TasksScreenTest {
 
     @Test
     fun markTaskAsComplete() = runTest {
-        repository.createTask("TITLE1", "DESCRIPTION1")
+        repository.create("TITLE1", "DESCRIPTION1")
 
         setContent()
 
@@ -134,7 +134,7 @@ class TasksScreenTest {
     @Test
     fun markTaskAsActive() = runTest {
         repository.apply {
-            createTask("TITLE1", "DESCRIPTION1").also { completeTask(it) }
+            create("TITLE1", "DESCRIPTION1").also { complete(it) }
         }
 
         setContent()
@@ -155,8 +155,8 @@ class TasksScreenTest {
     fun showAllTasks() = runTest {
         // Add one active task and one completed task
         repository.apply {
-            createTask("TITLE1", "DESCRIPTION1")
-            createTask("TITLE2", "DESCRIPTION2").also { completeTask(it) }
+            create("TITLE1", "DESCRIPTION1")
+            create("TITLE2", "DESCRIPTION2").also { complete(it) }
         }
 
         setContent()
@@ -171,9 +171,9 @@ class TasksScreenTest {
     fun showActiveTasks() = runTest {
         // Add 2 active tasks and one completed task
         repository.apply {
-            createTask("TITLE1", "DESCRIPTION1")
-            createTask("TITLE2", "DESCRIPTION2")
-            createTask("TITLE3", "DESCRIPTION3").also { completeTask(it) }
+            create("TITLE1", "DESCRIPTION1")
+            create("TITLE2", "DESCRIPTION2")
+            create("TITLE3", "DESCRIPTION3").also { complete(it) }
         }
 
         setContent()
@@ -189,9 +189,9 @@ class TasksScreenTest {
     fun showCompletedTasks() = runTest {
         // Add one active task and 2 completed tasks
         repository.apply {
-            createTask("TITLE1", "DESCRIPTION1")
-            createTask("TITLE2", "DESCRIPTION2").also { completeTask(it) }
-            createTask("TITLE3", "DESCRIPTION3").also { completeTask(it) }
+            create("TITLE1", "DESCRIPTION1")
+            create("TITLE2", "DESCRIPTION2").also { complete(it) }
+            create("TITLE3", "DESCRIPTION3").also { complete(it) }
         }
 
         setContent()
@@ -207,8 +207,8 @@ class TasksScreenTest {
     fun clearCompletedTasks() = runTest {
         // Add one active task and one completed task
         repository.apply {
-            createTask("TITLE1", "DESCRIPTION1")
-            createTask("TITLE2", "DESCRIPTION2").also { completeTask(it) }
+            create("TITLE1", "DESCRIPTION1")
+            create("TITLE2", "DESCRIPTION2").also { complete(it) }
         }
 
         setContent()

--- a/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksTest.kt
+++ b/app/src/androidTest/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksTest.kt
@@ -78,7 +78,7 @@ class TasksTest {
     @Test
     fun editTask() = runTest {
         val originalTaskTitle = "TITLE1"
-        repository.createTask(originalTaskTitle, "DESCRIPTION")
+        repository.create(originalTaskTitle, "DESCRIPTION")
 
         setContent()
 
@@ -143,8 +143,8 @@ class TasksTest {
     @Test
     fun createTwoTasks_deleteOneTask() = runTest {
         repository.apply {
-            createTask("TITLE1", "DESCRIPTION")
-            createTask("TITLE2", "DESCRIPTION")
+            create("TITLE1", "DESCRIPTION")
+            create("TITLE2", "DESCRIPTION")
         }
 
         setContent()
@@ -169,7 +169,7 @@ class TasksTest {
     fun markTaskAsCompleteOnDetailScreen_taskIsCompleteInList() = runTest {
         // Add 1 active task
         val taskTitle = "COMPLETED"
-        repository.createTask(taskTitle, "DESCRIPTION")
+        repository.create(taskTitle, "DESCRIPTION")
 
         setContent()
 
@@ -195,7 +195,7 @@ class TasksTest {
         // Add 1 completed task
         val taskTitle = "ACTIVE"
         repository.apply {
-            createTask(taskTitle, "DESCRIPTION").also { completeTask(it) }
+            create(taskTitle, "DESCRIPTION").also { complete(it) }
         }
 
         setContent()
@@ -221,7 +221,7 @@ class TasksTest {
     fun markTaskAsCompleteAndActiveOnDetailScreen_taskIsActiveInList() = runTest {
         // Add 1 active task
         val taskTitle = "ACT-COMP"
-        repository.createTask(taskTitle, "DESCRIPTION")
+        repository.create(taskTitle, "DESCRIPTION")
 
         setContent()
 
@@ -249,7 +249,7 @@ class TasksTest {
         // Add 1 completed task
         val taskTitle = "COMP-ACT"
         repository.apply {
-            createTask(taskTitle, "DESCRIPTION").also { completeTask(it) }
+            create(taskTitle, "DESCRIPTION").also { complete(it) }
         }
 
         setContent()

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/addedittask/AddEditTaskViewModel.kt
@@ -100,7 +100,7 @@ class AddEditTaskViewModel @Inject constructor(
     }
 
     private fun createNewTask() = viewModelScope.launch {
-        taskRepository.createTask(uiState.value.title, uiState.value.description)
+        taskRepository.create(uiState.value.title, uiState.value.description)
         _uiState.update {
             it.copy(isTaskSaved = true)
         }
@@ -111,7 +111,7 @@ class AddEditTaskViewModel @Inject constructor(
             throw RuntimeException("updateTask() was called but task is new.")
         }
         viewModelScope.launch {
-            taskRepository.updateTask(
+            taskRepository.update(
                 taskId,
                 title = uiState.value.title,
                 description = uiState.value.description,
@@ -127,7 +127,7 @@ class AddEditTaskViewModel @Inject constructor(
             it.copy(isLoading = true)
         }
         viewModelScope.launch {
-            taskRepository.getTask(taskId).let { task ->
+            taskRepository.get(taskId).let { task ->
                 if (task != null) {
                     _uiState.update {
                         it.copy(

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/TaskRepository.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/TaskRepository.kt
@@ -23,29 +23,29 @@ import kotlinx.coroutines.flow.Flow
  */
 interface TaskRepository {
 
-    fun getTasksStream(): Flow<List<Task>>
+    fun observeAll(): Flow<List<Task>>
 
-    suspend fun getTasks(forceUpdate: Boolean = false): List<Task>
+    suspend fun getAll(forceUpdate: Boolean = false): List<Task>
 
     suspend fun refresh()
 
-    fun getTaskStream(taskId: String): Flow<Task?>
+    fun observe(taskId: String): Flow<Task?>
 
-    suspend fun getTask(taskId: String, forceUpdate: Boolean = false): Task?
+    suspend fun get(taskId: String, forceUpdate: Boolean = false): Task?
 
-    suspend fun refreshTask(taskId: String)
+    suspend fun refresh(taskId: String)
 
-    suspend fun createTask(title: String, description: String): String
+    suspend fun create(title: String, description: String): String
 
-    suspend fun updateTask(taskId: String, title: String, description: String)
+    suspend fun update(taskId: String, title: String, description: String)
 
-    suspend fun completeTask(taskId: String)
+    suspend fun complete(taskId: String)
 
-    suspend fun activateTask(taskId: String)
+    suspend fun activate(taskId: String)
 
-    suspend fun clearCompletedTasks()
+    suspend fun clearAllCompleted()
 
-    suspend fun deleteAllTasks()
+    suspend fun deleteAll()
 
-    suspend fun deleteTask(taskId: String)
+    suspend fun delete(taskId: String)
 }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/statistics/StatisticsViewModel.kt
@@ -50,7 +50,7 @@ class StatisticsViewModel @Inject constructor(
 ) : ViewModel() {
 
     val uiState: StateFlow<StatisticsUiState> =
-        taskRepository.getTasksStream()
+        taskRepository.observeAll()
             .map { Async.Success(it) }
             .catch<Async<List<Task>>> { emit(Async.Error(R.string.loading_tasks_error)) }
             .map { taskAsync -> produceStatisticsUiState(taskAsync) }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModel.kt
@@ -59,7 +59,7 @@ class TaskDetailViewModel @Inject constructor(
     private val _userMessage: MutableStateFlow<Int?> = MutableStateFlow(null)
     private val _isLoading = MutableStateFlow(false)
     private val _isTaskDeleted = MutableStateFlow(false)
-    private val _taskAsync = taskRepository.getTaskStream(taskId)
+    private val _taskAsync = taskRepository.observe(taskId)
         .map { handleTask(it) }
         .catch { emit(Async.Error(R.string.loading_task_error)) }
 
@@ -93,17 +93,17 @@ class TaskDetailViewModel @Inject constructor(
         )
 
     fun deleteTask() = viewModelScope.launch {
-        taskRepository.deleteTask(taskId)
+        taskRepository.delete(taskId)
         _isTaskDeleted.value = true
     }
 
     fun setCompleted(completed: Boolean) = viewModelScope.launch {
         val task = uiState.value.task ?: return@launch
         if (completed) {
-            taskRepository.completeTask(task.id)
+            taskRepository.complete(task.id)
             showSnackbarMessage(R.string.task_marked_complete)
         } else {
-            taskRepository.activateTask(task.id)
+            taskRepository.activate(task.id)
             showSnackbarMessage(R.string.task_marked_active)
         }
     }
@@ -111,7 +111,7 @@ class TaskDetailViewModel @Inject constructor(
     fun refresh() {
         _isLoading.value = true
         viewModelScope.launch {
-            taskRepository.refreshTask(taskId)
+            taskRepository.refresh(taskId)
             _isLoading.value = false
         }
     }

--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksViewModel.kt
@@ -67,7 +67,7 @@ class TasksViewModel @Inject constructor(
     private val _userMessage: MutableStateFlow<Int?> = MutableStateFlow(null)
     private val _isLoading = MutableStateFlow(false)
     private val _filteredTasksAsync =
-        combine(taskRepository.getTasksStream(), _savedFilterType) { tasks, type ->
+        combine(taskRepository.observeAll(), _savedFilterType) { tasks, type ->
             filterTasks(tasks, type)
         }
             .map { Async.Success(it) }
@@ -105,7 +105,7 @@ class TasksViewModel @Inject constructor(
 
     fun clearCompletedTasks() {
         viewModelScope.launch {
-            taskRepository.clearCompletedTasks()
+            taskRepository.clearAllCompleted()
             showSnackbarMessage(R.string.completed_tasks_cleared)
             refresh()
         }
@@ -113,10 +113,10 @@ class TasksViewModel @Inject constructor(
 
     fun completeTask(task: Task, completed: Boolean) = viewModelScope.launch {
         if (completed) {
-            taskRepository.completeTask(task.id)
+            taskRepository.complete(task.id)
             showSnackbarMessage(R.string.task_marked_complete)
         } else {
-            taskRepository.activateTask(task.id)
+            taskRepository.activate(task.id)
             showSnackbarMessage(R.string.task_marked_active)
         }
     }

--- a/app/src/test/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModelTest.kt
+++ b/app/src/test/java/com/example/android/architecture/blueprints/todoapp/taskdetail/TaskDetailViewModelTest.kt
@@ -90,7 +90,7 @@ class TaskDetailViewModelTest {
 
     @Test
     fun activateTask() = runTest {
-        tasksRepository.deleteAllTasks()
+        tasksRepository.deleteAll()
         tasksRepository.addTasks(task.copy(isCompleted = true))
 
         // Verify that the task was completed initially
@@ -101,7 +101,7 @@ class TaskDetailViewModelTest {
         taskDetailViewModel.setCompleted(false)
 
         // Then the task is not completed and the snackbar shows the correct message
-        val newTask = tasksRepository.getTask(task.id)
+        val newTask = tasksRepository.get(task.id)
         assertTrue((newTask?.isActive) ?: false)
         assertThat(taskDetailViewModel.uiState.first().userMessage)
             .isEqualTo(R.string.task_marked_active)

--- a/shared-test/src/main/java/com/example/android/architecture/blueprints/todoapp/data/FakeTaskRepository.kt
+++ b/shared-test/src/main/java/com/example/android/architecture/blueprints/todoapp/data/FakeTaskRepository.kt
@@ -52,11 +52,11 @@ class FakeTaskRepository : TaskRepository {
         // Tasks already refreshed
     }
 
-    override suspend fun refreshTask(taskId: String) {
+    override suspend fun refresh(taskId: String) {
         refresh()
     }
 
-    override suspend fun createTask(title: String, description: String): String {
+    override suspend fun create(title: String, description: String): String {
         val taskId = generateTaskId()
         Task(title = title, description = description, id = taskId).also {
             saveTask(it)
@@ -64,29 +64,29 @@ class FakeTaskRepository : TaskRepository {
         return taskId
     }
 
-    override fun getTasksStream(): Flow<List<Task>> = observableTasks
+    override fun observeAll(): Flow<List<Task>> = observableTasks
 
-    override fun getTaskStream(taskId: String): Flow<Task?> {
+    override fun observe(taskId: String): Flow<Task?> {
         return observableTasks.map { tasks ->
             return@map tasks.firstOrNull { it.id == taskId }
         }
     }
 
-    override suspend fun getTask(taskId: String, forceUpdate: Boolean): Task? {
+    override suspend fun get(taskId: String, forceUpdate: Boolean): Task? {
         if (shouldThrowError) {
             throw Exception("Test exception")
         }
         return savedTasks.value[taskId]
     }
 
-    override suspend fun getTasks(forceUpdate: Boolean): List<Task> {
+    override suspend fun getAll(forceUpdate: Boolean): List<Task> {
         if (shouldThrowError) {
             throw Exception("Test exception")
         }
         return observableTasks.first()
     }
 
-    override suspend fun updateTask(taskId: String, title: String, description: String) {
+    override suspend fun update(taskId: String, title: String, description: String) {
         val updatedTask = _savedTasks.value[taskId]?.copy(
             title = title,
             description = description
@@ -103,19 +103,19 @@ class FakeTaskRepository : TaskRepository {
         }
     }
 
-    override suspend fun completeTask(taskId: String) {
+    override suspend fun complete(taskId: String) {
         _savedTasks.value[taskId]?.let {
             saveTask(it.copy(isCompleted = true))
         }
     }
 
-    override suspend fun activateTask(taskId: String) {
+    override suspend fun activate(taskId: String) {
         _savedTasks.value[taskId]?.let {
             saveTask(it.copy(isCompleted = false))
         }
     }
 
-    override suspend fun clearCompletedTasks() {
+    override suspend fun clearAllCompleted() {
         _savedTasks.update { tasks ->
             tasks.filterValues {
                 !it.isCompleted
@@ -123,7 +123,7 @@ class FakeTaskRepository : TaskRepository {
         }
     }
 
-    override suspend fun deleteTask(taskId: String) {
+    override suspend fun delete(taskId: String) {
         _savedTasks.update { tasks ->
             val newTasks = LinkedHashMap<String, Task>(tasks)
             newTasks.remove(taskId)
@@ -131,7 +131,7 @@ class FakeTaskRepository : TaskRepository {
         }
     }
 
-    override suspend fun deleteAllTasks() {
+    override suspend fun deleteAll() {
         _savedTasks.update {
             LinkedHashMap()
         }


### PR DESCRIPTION
Here's what I've done and why: 

- Removed `Task` from `TaskRepository` methods to avoid smurf naming e.g `createTask` becomes just `create`. 
- Changed `get` to `observe` for methods which return a `Flow`. This is less verbose and more accurate than `getTaskStream`.
- Methods which return a `List<Task>` have `All` after the verb e.g. `observeAll` and `clearAllCompleted. 