### PR TITLE
TextDecoration LineThrough-None

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreen.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/tasks/TasksScreen.kt
@@ -165,7 +165,9 @@ private fun TasksContent(
                     TaskItem(
                         task = task,
                         onTaskClick = onTaskClick,
-                        onCheckedChange = { onTaskCheckedChange(task, it) }
+                        onCheckedChange = {
+                            onTaskCheckedChange(task, it)
+                        }
                     )
                 }
             }
@@ -202,7 +204,7 @@ private fun TaskItem(
             textDecoration = if (task.isCompleted) {
                 TextDecoration.LineThrough
             } else {
-                null
+                TextDecoration.None
             }
         )
     }


### PR DESCRIPTION
If we assign null value after assigning value to textDecoration, it will not work as expected. We need to create an instance over the companion object.