### PR TITLE
Migrated Hilt Kapt to Ksp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -128,7 +128,7 @@ dependencies {
     // Hilt
     implementation(libs.hilt.android.core)
     implementation(libs.androidx.hilt.navigation.compose)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     // Jetpack Compose
     val composeBom = platform(libs.androidx.compose.bom)

--- a/shared-test/build.gradle.kts
+++ b/shared-test/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation(libs.androidx.test.rules)
     implementation(libs.hilt.android.core)
     implementation(libs.hilt.android.testing)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     // Room
     implementation(libs.room.runtime)


### PR DESCRIPTION
This PR resolves: #975 

TODO: `kaptTest(libs.hilt.compiler)` needs to be migrated too.

Please review: @manuelvicnt
