### PR TITLE
Fix failing lint task in shared-test

### DIFF
--- a/shared-test/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/FakeTaskDao.kt
+++ b/shared-test/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/local/FakeTaskDao.kt
@@ -16,6 +16,8 @@
 
 package com.example.android.architecture.blueprints.todoapp.data.source.local
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import kotlinx.coroutines.flow.Flow
 
 class FakeTaskDao(initialTasks: List<LocalTask>? = emptyList()) : TaskDao {
@@ -60,6 +62,7 @@ class FakeTaskDao(initialTasks: List<LocalTask>? = emptyList()) : TaskDao {
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.N)
     override suspend fun deleteCompleted(): Int {
         _tasks?.apply {
             val originalSize = size


### PR DESCRIPTION
When you run `./gradlew clean build`, the `:shared-test:lintDebug` task will fail:

```console
FakeTaskDao.kt:66: Error: Call requires API level 24 (current min is 21): java.util.Collection#removeIf [NewApi]
              entries.removeIf { it.value.isCompleted }
                      ~~~~~~~~
```

A proposed solution is to label the enclosing function with `@RequiresApi(Build.VERSION_CODES.N)`. With that change in place, `./gradlew clean build` can now complete successfully.