### PR TITLE
Use event queue to avoid heap allocated coroutineScope

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepository.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/DefaultTaskRepository.kt
@@ -57,7 +57,7 @@ class DefaultTaskRepository @Inject constructor(
     }
 
     /**
-     * Send the tasks from the local data source to the network data sources.
+     * Send the tasks from the local data source to the network data source.
      *
      * Real apps may want to use WorkManager to schedule this work, and provide a mechanism for
      * failures to be communicated back to the user so that they are aware that their data isn't


### PR DESCRIPTION
**What have I done and why**
Added a queue for network sync events, implemented using a `Channel`. This avoids having a heap allocated coroutine scope which might fail silently.  