### PR TITLE
Remove saveTasks() parameter ambiguity

### DIFF
--- a/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/network/NetworkDataSource.kt
+++ b/app/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/network/NetworkDataSource.kt
@@ -24,5 +24,5 @@ interface NetworkDataSource {
 
     suspend fun loadTasks(): List<NetworkTask>
 
-    suspend fun saveTasks(tasks: List<NetworkTask>)
+    suspend fun saveTasks(newTasks: List<NetworkTask>)
 }

--- a/shared-test/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/network/FakeNetworkDataSource.kt
+++ b/shared-test/src/main/java/com/example/android/architecture/blueprints/todoapp/data/source/network/FakeNetworkDataSource.kt
@@ -21,7 +21,7 @@ class FakeNetworkDataSource(
 ) : NetworkDataSource {
     override suspend fun loadTasks() = tasks ?: throw Exception("Task list is null")
 
-    override suspend fun saveTasks(tasks: List<NetworkTask>) {
-        this.tasks = tasks.toMutableList()
+    override suspend fun saveTasks(newTasks: List<NetworkTask>) {
+        this.tasks = newTasks.toMutableList()
     }
 }


### PR DESCRIPTION
Remove NetworkDataSource.saveTasks() parameter ambiguity specifically for FakeNetworkDataSource implementation.