### PR TITLE
Upgrade actions/setup-java to v6

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -31,7 +31,7 @@ jobs:
         run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
       - name: Set Up JDK
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v6
         with:
           distribution: 'zulu' # See 'Supported distributions' for available options
           java-version: '17'


### PR DESCRIPTION
Upgrade the build workflow from `actions/setup-java@v4` to `@v6`, preserving the repository semantic version pin style.

Validation: verified no older `actions/setup-java` references remain in active workflow YAML and ran `git diff --check`.